### PR TITLE
feat: add native Apple-silicon macOS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,15 @@
 # Copy to .env and fill in your values.
-# Only these variables are read by the Go backend (see main.go / internal/supabase/client.go).
-# Never put server-side secrets (service keys, JWT secrets) in this file or .env.
+# Desktop reads this file for local development. Release builds receive the same
+# values from GitHub Actions secrets and embed only the client configuration.
+# Never use a Supabase service-role key or JWT secret here.
 
 TMDB_API_KEY=your_tmdb_api_key_here
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_PUBLISHABLE_KEY=your_supabase_publishable_key_here
+
+# Optional integrations.
+TRAKT_CLIENT_ID=your_trakt_client_id_here
+TRAKT_CLIENT_SECRET=your_trakt_client_secret_here
 
 # Optional — override listen address / data directories (defaults suit local dev).
 # COVE_BIND_ADDR=127.0.0.1:6969

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,36 @@ jobs:
           :mobile:assembleDebug
           --no-daemon
 
+  macos:
+    name: macOS native build and test
+    runs-on: macos-15
+    timeout-minutes: 35
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v5
+      - name: Install libmpv
+        run: brew install mpv
+      - name: Test and build Apple-silicon application
+        working-directory: app
+        run: >-
+          ./gradlew
+          :backend:desktopTest
+          :ui:desktopTest
+          :desktop:test
+          :desktop:createDistributable
+          --no-daemon
+      - name: Verify application bundle
+        run: |
+          set -euo pipefail
+          APP=app/desktop/build/compose/binaries/main/app/Cove.app
+          test -x "$APP/Contents/MacOS/Cove"
+          test "$(plutil -extract CFBundleIdentifier raw "$APP/Contents/Info.plist")" = io.github.coveninja.Cove
+          file "$APP/Contents/MacOS/Cove" | grep -q arm64
+
   android-smoke:
     name: Android phone launch smoke test
     needs: [kotlin]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,18 @@ jobs:
           PUBLIC_KEYS="${TRUSTED:+$TRUSTED,}$KEY_ID=$PUBLIC"
           echo "key_id=$KEY_ID" >> "$GITHUB_OUTPUT"
           echo "public_keys=$PUBLIC_KEYS" >> "$GITHUB_OUTPUT"
+      - name: Validate client release configuration
+        env:
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}
+        run: |
+          set -euo pipefail
+          for name in TMDB_API_KEY SUPABASE_URL SUPABASE_PUBLISHABLE_KEY TRAKT_CLIENT_ID TRAKT_CLIENT_SECRET; do
+            test -n "${!name}" || { echo "::error::$name is not configured"; exit 1; }
+          done
 
   kotlin:
     name: Kotlin desktop/mobile build and test
@@ -238,6 +250,116 @@ jobs:
             cove-windows-amd64-portable.zip
             cove-windows-amd64-portable.zip.sha256
 
+  package-macos:
+    name: Package signed macOS asset
+    needs: [update-key, kotlin]
+    runs-on: macos-15
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '21'
+      - uses: gradle/actions/setup-gradle@v5
+      - name: Install native packaging dependencies
+        run: brew install mpv dylibbundler
+      - name: Import Developer ID certificate
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.MACOS_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          test -n "$CERTIFICATE_BASE64" || { echo '::error::MACOS_CERTIFICATE_BASE64 is not configured'; exit 1; }
+          KEYCHAIN_PASSWORD=$(uuidgen)
+          KEYCHAIN_PATH="$RUNNER_TEMP/cove-signing.keychain-db"
+          CERTIFICATE_PATH="$RUNNER_TEMP/cove-developer-id.p12"
+          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -P "$CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          SIGNING_IDENTITY=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | awk -F'"' '/Developer ID Application/{print $2; exit}')
+          test -n "$SIGNING_IDENTITY" || { echo '::error::The certificate contains no Developer ID Application identity'; exit 1; }
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >> "$GITHUB_ENV"
+          echo "SIGNING_IDENTITY=$SIGNING_IDENTITY" >> "$GITHUB_ENV"
+      - name: Build signed Compose application
+        working-directory: app
+        env:
+          UPDATE_PUBLIC_KEYS: ${{ needs.update-key.outputs.public_keys }}
+          TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_PUBLISHABLE_KEY: ${{ secrets.SUPABASE_PUBLISHABLE_KEY }}
+          TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
+          TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}
+        run: >-
+          ./gradlew :desktop:createDistributable --no-daemon
+          -Pcompose.desktop.mac.sign=true
+          -Pcompose.desktop.mac.signing.identity="$SIGNING_IDENTITY"
+          -Pcompose.desktop.mac.signing.keychain="$KEYCHAIN_PATH"
+      - name: Bundle libmpv and verify native closure
+        run: |
+          set -euo pipefail
+          APP=app/desktop/build/compose/binaries/main/app/Cove.app
+          FRAMEWORKS="$APP/Contents/Frameworks"
+          mkdir -p "$FRAMEWORKS"
+          cp "$(brew --prefix mpv)/lib/libmpv.2.dylib" "$FRAMEWORKS/libmpv.2.dylib"
+          dylibbundler -of -cd -b -x "$FRAMEWORKS/libmpv.2.dylib" \
+            -d "$FRAMEWORKS" -p '@loader_path/'
+          # Homebrew's libmpv already carries this rpath. dylibbundler adds it
+          # again, and dyld rejects a Mach-O containing duplicate LC_RPATHs.
+          while [ "$(otool -l "$FRAMEWORKS/libmpv.2.dylib" \
+            | awk '/LC_RPATH/{getline; getline; if ($0 ~ /@loader_path\//) count++} END{print count+0}')" -gt 1 ]; do
+            install_name_tool -delete_rpath '@loader_path/' "$FRAMEWORKS/libmpv.2.dylib"
+          done
+          ln -s libmpv.2.dylib "$FRAMEWORKS/libmpv.dylib"
+          for library in "$FRAMEWORKS"/*.dylib; do
+            # The first listed path is the dylib's install id, not a dependency.
+            external=$(otool -L "$library" | tail -n +3 \
+              | awk '{print $1}' \
+              | grep -E '^(/opt/homebrew|/usr/local)' || true)
+            test -z "$external" || { echo "::error::$library still references $external"; exit 1; }
+          done
+          find "$FRAMEWORKS" -type f -name '*.dylib' -print0 \
+            | xargs -0 -n1 codesign --force --options runtime --timestamp \
+              --keychain "$KEYCHAIN_PATH" --sign "$SIGNING_IDENTITY"
+          python3 -c 'import ctypes,sys; ctypes.CDLL(sys.argv[1])' "$FRAMEWORKS/libmpv.2.dylib"
+          codesign --force --options runtime --timestamp \
+            --entitlements packaging/macos/entitlements.plist \
+            --keychain "$KEYCHAIN_PATH" \
+            --sign "$SIGNING_IDENTITY" "$APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
+      - name: Create and notarize DMG
+        env:
+          APPLE_ID: ${{ secrets.APPLE_NOTARIZATION_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          set -euo pipefail
+          test -n "$APPLE_ID" || { echo '::error::APPLE_NOTARIZATION_ID is not configured'; exit 1; }
+          test -n "$APPLE_PASSWORD" || { echo '::error::APPLE_NOTARIZATION_PASSWORD is not configured'; exit 1; }
+          test -n "$APPLE_TEAM_ID" || { echo '::error::APPLE_TEAM_ID is not configured'; exit 1; }
+          mkdir dmg-root
+          ditto app/desktop/build/compose/binaries/main/app/Cove.app dmg-root/Cove.app
+          ln -s /Applications dmg-root/Applications
+          hdiutil create -volname Cove -srcfolder dmg-root -ov -format UDZO cove-macos-arm64.dmg
+          codesign --force --timestamp --keychain "$KEYCHAIN_PATH" \
+            --sign "$SIGNING_IDENTITY" cove-macos-arm64.dmg
+          xcrun notarytool submit cove-macos-arm64.dmg \
+            --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" --wait
+          xcrun stapler staple cove-macos-arm64.dmg
+          xcrun stapler validate cove-macos-arm64.dmg
+          shasum -a 256 cove-macos-arm64.dmg > cove-macos-arm64.dmg.sha256
+      - uses: actions/upload-artifact@v4
+        with:
+          name: macos-release-assets
+          if-no-files-found: error
+          path: |
+            cove-macos-arm64.dmg
+            cove-macos-arm64.dmg.sha256
+
   package-android:
     name: Package Android asset
     needs: [update-key, kotlin]
@@ -289,7 +411,7 @@ jobs:
 
   publish-release:
     name: Sign manifest and publish complete release
-    needs: [update-key, package-linux, package-windows, package-android]
+    needs: [update-key, package-linux, package-windows, package-macos, package-android]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
   <p>
     Cove brings a personal library, rich discovery, extensible sources, and
-    hardware-accelerated playback to Linux, Windows, and Android phones, tablets,
-    and televisions.
+    hardware-accelerated playback to Linux, Windows, macOS, and Android phones,
+    tablets, and televisions.
   </p>
 
   <p>
@@ -66,7 +66,7 @@
 | Windows | Available | Installer, portable ZIP | Verified in-app updates for both forms beginning with `1.0.0` |
 | Android phone/tablet | Preview | APK, Android 9+ | Verified APK through Android's package installer |
 | Android TV | Preview | Same APK, Android 9+ | Verified APK through Android's package installer |
-| macOS | Not available | — | No native build or packaging yet |
+| macOS (Apple silicon) | Available | Signed and notarized DMG | Manual release replacement |
 
 One APK serves both phones and televisions: `leanback` is declared optional, and
 the app selects the touch or ten-foot shell at runtime from `FEATURE_LEANBACK`.
@@ -128,6 +128,12 @@ Both distributions support signed, verified in-app updates beginning with
 > ZIP above and install it yourself; those older builds will not offer `1.0.0`
 > in-app, by design. Your library, profiles, and settings are preserved.
 
+### macOS
+
+Download `cove-macos-arm64.dmg`, open it, and drag Cove into Applications. The
+release bundle is signed, notarized, and includes libmpv and its native runtime
+dependencies; viewers do not need Homebrew or a separate API key.
+
 ### Android phone, tablet, and TV
 
 Download and install `cove-android.apk` on Android 9 (API 28) or newer. The same
@@ -145,7 +151,7 @@ release is signed with the same key and carries a higher version code.
 ### Prerequisites
 
 - JDK 21
-- libmpv (`mpv` on Arch/CachyOS or `libmpv-dev` on Debian/Ubuntu)
+- libmpv (`mpv` on Arch/CachyOS and Homebrew, or `libmpv-dev` on Debian/Ubuntu)
 - Android SDK platform and build-tools 36 for Android builds
 - A TMDB API key for live catalog data
 
@@ -177,6 +183,18 @@ Common development commands:
 | `make test` | Run the Kotlin test suites |
 | `make test-build` | Build the desktop image and Android debug APK |
 | `make test-all` | Run the broadest local approximation of CI |
+
+On macOS, Homebrew provides both required local dependencies and Gradle can
+create a native application bundle for the current Apple-silicon Mac:
+
+```sh
+brew install mpv
+brew install --cask temurin@21
+export JAVA_HOME="$(/usr/libexec/java_home -v 21)"
+cd app
+./gradlew :desktop:createDistributable --no-daemon
+open desktop/build/compose/binaries/main/app/Cove.app
+```
 
 Desktop configuration is loaded from environment variables, the nearest `.env`,
 and then bundled release properties. Android receives the same deployment values

--- a/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/torrent/NativePreloads.kt
+++ b/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/torrent/NativePreloads.kt
@@ -22,7 +22,10 @@ internal object NativePreloads {
     private var done = false
 
     @Synchronized
-    fun install() {
+    fun install(osName: String = System.getProperty("os.name")) {
+        // These mitigations target glibc/libstdc++ and Linux signal ownership.
+        // Darwin uses libc++ and different signal constants/structures.
+        if (!needsLinuxNativePreloads(osName)) return
         if (done) return
         done = true
         FatalSignalHandlers.guard()
@@ -52,3 +55,6 @@ internal object NativePreloads {
         }.onFailure { System.err.println("Cove torrent: could not preload libstdc++ (${it.message})") }
     }
 }
+
+internal fun needsLinuxNativePreloads(osName: String): Boolean =
+    osName.startsWith("Linux", ignoreCase = true)

--- a/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/torrent/NativePreloadsTest.kt
+++ b/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/torrent/NativePreloadsTest.kt
@@ -1,0 +1,14 @@
+package com.coveninja.cove.backend.torrent
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NativePreloadsTest {
+    @Test
+    fun `glibc preloads run only on Linux`() {
+        assertTrue(needsLinuxNativePreloads("Linux"))
+        assertFalse(needsLinuxNativePreloads("Mac OS X"))
+        assertFalse(needsLinuxNativePreloads("Windows 11"))
+    }
+}

--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -81,10 +81,21 @@ dependencies {
     // Native JARs cannot be expressed in the version catalog (no classifier
     // support), so they are declared here with explicit coordinates.
     val joglVersion = libs.versions.jogl.get()
+    val osName = System.getProperty("os.name")
+    val osArch = System.getProperty("os.arch")
+    val joglNatives = when {
+        osName.startsWith("Mac", ignoreCase = true) -> "natives-macosx-universal"
+        osName.startsWith("Windows", ignoreCase = true) -> "natives-windows-amd64"
+        osName.startsWith("Linux", ignoreCase = true) &&
+            (osArch.equals("aarch64", ignoreCase = true) || osArch.equals("arm64", ignoreCase = true)) ->
+            "natives-linux-aarch64"
+        osName.startsWith("Linux", ignoreCase = true) -> "natives-linux-amd64"
+        else -> error("Unsupported desktop platform: $osName ($osArch)")
+    }
     implementation(libs.jogl.all)
-    runtimeOnly("org.jogamp.jogl:jogl-all:$joglVersion:natives-linux-amd64")
+    runtimeOnly("org.jogamp.jogl:jogl-all:$joglVersion:$joglNatives")
     implementation(libs.gluegen.rt)
-    runtimeOnly("org.jogamp.gluegen:gluegen-rt:$joglVersion:natives-linux-amd64")
+    runtimeOnly("org.jogamp.gluegen:gluegen-rt:$joglVersion:$joglNatives")
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)
 }
@@ -110,7 +121,6 @@ compose.desktop {
             targetFormats(TargetFormat.Deb, TargetFormat.Msi, TargetFormat.Dmg)
             packageName    = "Cove"
             packageVersion = coveVersion
-
             // The same mark the Windows installer, the Flatpak and the README already use.
             // jpackage wants a different container per platform and silently falls back to a
             // generic Java icon when one is missing, which is what every package shipped until
@@ -118,7 +128,13 @@ compose.desktop {
             val iconDir = rootProject.file("../packaging/icons")
             linux { iconFile.set(iconDir.resolve("cove.png")) }
             windows { iconFile.set(iconDir.resolve("cove.ico")) }
-            macOS { iconFile.set(iconDir.resolve("cove.icns")) }
+            macOS {
+                bundleID = "io.github.coveninja.Cove"
+                iconFile.set(iconDir.resolve("cove.icns"))
+                val entitlements = rootProject.file("../packaging/macos/entitlements.plist")
+                entitlementsFile.set(entitlements)
+                runtimeEntitlementsFile.set(entitlements)
+            }
         }
     }
 }

--- a/app/desktop/src/main/kotlin/com/coveninja/cove/desktop/Main.kt
+++ b/app/desktop/src/main/kotlin/com/coveninja/cove/desktop/Main.kt
@@ -49,6 +49,9 @@ import kotlinx.coroutines.delay
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) {
+    if (System.getProperty("os.name").startsWith("Mac", ignoreCase = true)) {
+        System.setProperty("apple.awt.application.name", "Cove")
+    }
     val parsedOptions = LaunchOptions.parse(args)
     val environmentMode = System.getenv("COVE_BACKEND_MODE")
         ?.takeIf(String::isNotBlank)

--- a/app/desktop/src/main/kotlin/com/coveninja/cove/desktop/player/Mpv.kt
+++ b/app/desktop/src/main/kotlin/com/coveninja/cove/desktop/player/Mpv.kt
@@ -3,10 +3,12 @@ package com.coveninja.cove.desktop.player
 import com.sun.jna.Callback
 import com.sun.jna.Library
 import com.sun.jna.Native
+import com.sun.jna.NativeLibrary
 import com.sun.jna.Platform
 import com.sun.jna.Pointer
 import com.sun.jna.Structure
 import com.sun.jna.ptr.PointerByReference
+import java.nio.file.Path
 
 internal object Mpv {
     // mpv_format enum values from client.h
@@ -52,6 +54,11 @@ internal object Mpv {
         val instance: MpvLibrary = load()
 
         private fun load(): MpvLibrary {
+            mpvLibrarySearchPaths(
+                osName = System.getProperty("os.name"),
+                environment = System.getenv(),
+                javaHome = System.getProperty("java.home"),
+            ).forEach { path -> NativeLibrary.addSearchPath("mpv", path) }
             // Windows ships the DLL as mpv-2; Linux/macOS as mpv.
             val candidates = if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
                 listOf("mpv-2", "mpv")
@@ -73,6 +80,29 @@ internal object Mpv {
         }
     }
 }
+
+/**
+ * Finder-launched macOS apps do not inherit Homebrew's shell path. Add the two
+ * standard Homebrew prefixes explicitly while retaining an override for other
+ * package layouts. JNA still performs its normal system search afterwards.
+ */
+internal fun mpvLibrarySearchPaths(
+    osName: String,
+    environment: Map<String, String>,
+    javaHome: String = System.getProperty("java.home"),
+): List<String> = buildList {
+    environment["COVE_MPV_LIBRARY_DIR"]?.trim()?.takeIf(String::isNotEmpty)?.let(::add)
+    if (osName.startsWith("Mac", ignoreCase = true)) {
+        // jpackage puts the runtime at Cove.app/Contents/runtime/Contents/Home.
+        // Release builds place a self-contained libmpv closure beside it.
+        Path.of(javaHome).parent?.parent?.parent
+            ?.resolve("Frameworks")
+            ?.toString()
+            ?.let(::add)
+        add("/opt/homebrew/opt/mpv/lib")
+        add("/usr/local/opt/mpv/lib")
+    }
+}.distinct()
 
 private object NativeNumericLocale {
     private val lib: NativeLocaleLibrary by lazy {

--- a/app/desktop/src/test/kotlin/com/coveninja/cove/desktop/player/MpvTest.kt
+++ b/app/desktop/src/test/kotlin/com/coveninja/cove/desktop/player/MpvTest.kt
@@ -19,6 +19,23 @@ import kotlin.test.assertFailsWith
  */
 class MpvTest {
 
+    @Test
+    fun `macOS searches both Homebrew libmpv prefixes`() {
+        assertEquals(
+            listOf(
+                "/custom/mpv",
+                "/Applications/Cove.app/Contents/Frameworks",
+                "/opt/homebrew/opt/mpv/lib",
+                "/usr/local/opt/mpv/lib",
+            ),
+            mpvLibrarySearchPaths(
+                osName = "Mac OS X",
+                environment = mapOf("COVE_MPV_LIBRARY_DIR" to "/custom/mpv"),
+                javaHome = "/Applications/Cove.app/Contents/runtime/Contents/Home",
+            ),
+        )
+    }
+
     // ---- lcNumericCategory ----
 
     @Test

--- a/docs/UPDATES.md
+++ b/docs/UPDATES.md
@@ -3,8 +3,8 @@
 Cove's in-process updater is available for Windows installer and portable
 builds, and for the Android APK on phones, tablets, and televisions — one APK
 carries the updater and both shells wire the update overlay. AUR installs remain
-owned by `pacman`; standalone Flatpak bundles and tarballs are replaced manually.
-macOS does not currently ship an updater.
+owned by `pacman`; standalone Flatpak bundles, tarballs, and macOS DMG
+installations are replaced manually.
 
 Automatic updates are enabled per device by default. Cove checks shortly after
 launch and no more than once every 24 hours while the process remains open. It
@@ -75,3 +75,35 @@ the signing secret and `UPDATE_SIGNING_KEY_ID` with the next key while retaining
 both public entries. Remove the old public key only in a later next-key-signed
 release. A compromised key requires a manual package update for clients that did
 not receive a trusted bridge release.
+
+## Provider and macOS release configuration
+
+Release builds use the same repository secrets on Linux, Windows, macOS, and
+Android. Add each value once under **Settings → Secrets and variables → Actions**:
+
+| Secret | Purpose |
+|---|---|
+| `TMDB_API_KEY` | TMDB v3 client key used for catalog metadata |
+| `SUPABASE_URL` | Cove's Supabase project URL |
+| `SUPABASE_PUBLISHABLE_KEY` | Public/publishable Supabase client key |
+| `TRAKT_CLIENT_ID` | Trakt OAuth client id |
+| `TRAKT_CLIENT_SECRET` | Trakt OAuth client secret |
+
+The Gradle build reads those values directly from its environment and writes the
+client configuration into each package. Do not configure a Supabase service-role
+key or JWT secret: Cove clients neither need nor accept server authority.
+
+The Apple-silicon DMG additionally requires:
+
+| Secret | Purpose |
+|---|---|
+| `MACOS_CERTIFICATE_BASE64` | Base64 PKCS#12 containing a Developer ID Application certificate and private key |
+| `MACOS_CERTIFICATE_PASSWORD` | PKCS#12 export password |
+| `APPLE_NOTARIZATION_ID` | Apple account used by `notarytool` |
+| `APPLE_NOTARIZATION_PASSWORD` | App-specific Apple password |
+| `APPLE_TEAM_ID` | Apple Developer team identifier |
+
+The release job imports the certificate into an ephemeral runner keychain,
+signs the Compose app and bundled libmpv closure, notarizes the final DMG, and
+publishes it only after Apple's ticket validates. None of these values belongs
+in `.env`, source files, Gradle properties, or the Git history.

--- a/packaging/macos/entitlements.plist
+++ b/packaging/macos/entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "https://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- HotSpot and GraalJS compile code at runtime. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+
+    <!-- JNA/JNI load the packaged mpv, torrent, SQLite, JOGL and Skiko libraries. -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- enable the current Compose desktop app on Apple silicon, including Darwin-safe native startup, macOS JOGL natives, Cove bundle identity, icon, and entitlements
- package a self-contained signed and notarized DMG whose bundled libmpv closure does not require Homebrew on viewer machines
- add an Apple-silicon CI build and extend the existing release workflow with a macOS artifact

The branch is rebased on current `master`; the upstream onboarding implementation in `ui/onboarding/` is retained unchanged.

## Owner configuration

No credential helper or setup script is added. Release builds read the existing client configuration directly from standard GitHub Actions repository secrets:

- `TMDB_API_KEY`
- `SUPABASE_URL`
- `SUPABASE_PUBLISHABLE_KEY`
- `TRAKT_CLIENT_ID`
- `TRAKT_CLIENT_SECRET`

The macOS release job additionally uses `MACOS_CERTIFICATE_BASE64`, `MACOS_CERTIFICATE_PASSWORD`, `APPLE_NOTARIZATION_ID`, `APPLE_NOTARIZATION_PASSWORD`, and `APPLE_TEAM_ID`. `docs/UPDATES.md` documents where each value goes and explicitly excludes Supabase service-role and JWT secrets.

## Validation

- `actionlint .github/workflows/*.yml` and the repository workflow/release-note checks pass
- `./gradlew :backend:desktopTest :ui:desktopTest :desktop:test :desktop:createDistributable --rerun-tasks --no-daemon` passes (35 tasks executed)
- `:desktop:createDistributable` produces an arm64 app with bundle id `io.github.coveninja.Cove` and passes deep strict code-signature verification
- the bundled 48-dylib libmpv closure has no Homebrew runtime dependencies and passes deep strict code-signature verification
- the packaged app loads libmpv from `Cove.app/Contents/Frameworks` and renders a generated local H.264 playback probe

The Android aggregate was not run locally because this Mac has no Android SDK; the existing GitHub workflow installs the required Android platform and remains the mobile verification gate.
