### PR TITLE
fix: prevent torrent SIGSEGV crashes on macOS and Linux

### DIFF
--- a/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/torrent/JlibtorrentPlaybackEngine.kt
+++ b/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/torrent/JlibtorrentPlaybackEngine.kt
@@ -2,6 +2,7 @@ package com.coveninja.cove.backend.torrent
 
 import com.frostwire.jlibtorrent.Priority
 import com.frostwire.jlibtorrent.SessionManager
+import com.frostwire.jlibtorrent.SessionParams
 import com.frostwire.jlibtorrent.SettingsPack
 import com.frostwire.jlibtorrent.Sha1Hash
 import com.frostwire.jlibtorrent.TorrentFlags
@@ -336,7 +337,7 @@ class JlibtorrentPlaybackEngine(
         NativePreloads.install()
         manager ?: run {
             SessionManager(false).also {
-                it.start()
+                startTorrentSession(it, System.getProperty("os.name"))
                 it.applySettings(streamingSettings())
                 manager = it
                 log("session started, running=${it.isRunning}")
@@ -526,6 +527,25 @@ class JlibtorrentPlaybackEngine(
         var raisedTo: Int = -1
     }
 }
+
+internal fun startTorrentSession(
+    manager: SessionManager,
+    osName: String,
+    paramsFactory: () -> SessionParams = ::SessionParams,
+) {
+    if (needsPosixTorrentDiskIo(osName)) {
+        // libtorrent's mmap backend installs process-wide SIGSEGV/SIGBUS handlers.
+        // On macOS and Linux they displace HotSpot's handlers, so faults the JVM normally
+        // handles can terminate the process.
+        manager.start(paramsFactory().apply { setPosixDiskIO() })
+    } else {
+        manager.start()
+    }
+}
+
+internal fun needsPosixTorrentDiskIo(osName: String): Boolean =
+    osName.startsWith("Mac", ignoreCase = true) ||
+        osName.startsWith("Linux", ignoreCase = true)
 
 /** How much further ahead of the served chunk pieces are asked for. */
 private const val READ_AHEAD_BYTES = 32L * 1024 * 1024

--- a/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/torrent/JlibtorrentPlaybackEngineTest.kt
+++ b/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/torrent/JlibtorrentPlaybackEngineTest.kt
@@ -1,0 +1,73 @@
+package com.coveninja.cove.backend.torrent
+
+import com.frostwire.jlibtorrent.SessionManager
+import com.frostwire.jlibtorrent.SessionParams
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/** Guards the real session-start calls, not just the platform predicate that selects them. */
+class JlibtorrentPlaybackEngineTest {
+    @Test
+    fun `POSIX disk IO is selected on macOS and Linux`() {
+        assertTrue(needsPosixTorrentDiskIo("Mac OS X"))
+        assertTrue(needsPosixTorrentDiskIo("macOS"))
+        assertTrue(needsPosixTorrentDiskIo("Linux"))
+        assertFalse(needsPosixTorrentDiskIo("Windows 11"))
+    }
+
+    @Test
+    fun `macOS and Linux sessions start with POSIX disk IO parameters`() {
+        listOf("Mac OS X", "Linux").forEach { osName ->
+            val manager = RecordingSessionManager()
+            val params = RecordingSessionParams()
+
+            startTorrentSession(manager, osName) { params }
+
+            assertEquals(0, manager.defaultStartCalls, osName)
+            assertEquals(1, manager.paramsStartCalls, osName)
+            assertSame(params, manager.startedWith, osName)
+            assertEquals(1, params.posixSelections, osName)
+        }
+    }
+
+    @Test
+    fun `Windows sessions retain the default disk IO backend`() {
+        val manager = RecordingSessionManager()
+        var paramsCreated = false
+
+        startTorrentSession(manager, "Windows 11") {
+            paramsCreated = true
+            RecordingSessionParams()
+        }
+
+        assertEquals(1, manager.defaultStartCalls)
+        assertEquals(0, manager.paramsStartCalls)
+        assertFalse(paramsCreated)
+    }
+
+    private class RecordingSessionManager : SessionManager(false) {
+        var defaultStartCalls = 0
+        var paramsStartCalls = 0
+        var startedWith: SessionParams? = null
+
+        override fun start() {
+            defaultStartCalls += 1
+        }
+
+        override fun start(params: SessionParams) {
+            paramsStartCalls += 1
+            startedWith = params
+        }
+    }
+
+    private class RecordingSessionParams : SessionParams() {
+        var posixSelections = 0
+
+        override fun setPosixDiskIO() {
+            posixSelections += 1
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- select libtorrent's POSIX disk I/O backend on macOS and Linux so mmap storage cannot replace HotSpot's fatal-signal handlers
- preserve the default backend on Windows and other platforms
- add platform-selection and real session-start coverage

## Validation

- macOS backend, UI, and desktop tests pass
- macOS distributable builds successfully
- Linux backend tests and desktop distributable pass
- Android debug APK assembles successfully

## Follow-up

This may make parts of the existing libjsig/watchdog handling redundant. I've left them unchanged to keep this fix focused, but I'm happy to clean them up separately if you prefer.
