### PR TITLE
fix: make torrent cache deletion atomic

### DIFF
--- a/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/AndroidBackendRuntime.kt
+++ b/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/AndroidBackendRuntime.kt
@@ -39,6 +39,7 @@ import com.coveninja.cove.backend.storage.CacheDirectories
 import com.coveninja.cove.backend.storage.CacheStorageService
 import com.coveninja.cove.backend.storage.LocalStorageRepository
 import com.coveninja.cove.backend.storage.TorrentCacheJournal
+import com.coveninja.cove.backend.torrent.TorrentCacheLifecycle
 import com.coveninja.cove.backend.torrent.TorrentPlaybackEngine
 import com.coveninja.cove.shared.data.StorageRepository
 import com.coveninja.cove.shared.data.TorrentCachePolicy
@@ -283,6 +284,7 @@ class AndroidBackendRuntime private constructor(
                     // the storage screen could ask what is playing. Until it exists nothing can
                     // be playing, which is exactly what an absent reference reports.
                     val engineRef = java.util.concurrent.atomic.AtomicReference<TorrentPlaybackEngine?>()
+                    val torrentLifecycle = TorrentCacheLifecycle()
                     val media = LazyAndroidPlaybackMediaHost {
                         AndroidPlaybackMediaHost.start(
                             httpClient = untrustedClient,
@@ -294,6 +296,7 @@ class AndroidBackendRuntime private constructor(
                             },
                             torrentEngine = AndroidJlibtorrentPlaybackEngine(
                                 downloadDirectory = torrentDirectory,
+                                lifecycle = torrentLifecycle,
                                 policy = cachePolicy::value,
                                 journal = cacheJournal,
                             ).also(engineRef::set),
@@ -308,6 +311,7 @@ class AndroidBackendRuntime private constructor(
                             // it, and it is journalled — deleting its files from underneath it
                             // is not the same operation as clearing it.
                             directories = CacheDirectories(torrents = torrentDirectory),
+                            torrentLifecycle = torrentLifecycle,
                             journal = cacheJournal,
                             activeHashes = { engineRef.get()?.activeHashes().orEmpty() },
                             release = { hash -> engineRef.get()?.release(hash) ?: true },

--- a/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/playback/AndroidPlaybackMediaHost.kt
+++ b/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/playback/AndroidPlaybackMediaHost.kt
@@ -208,7 +208,7 @@ internal class AndroidPlaybackMediaHost private constructor(
             status = if (range.partial) HttpStatusCode.PartialContent else HttpStatusCode.OK,
             contentLength = range.endInclusive - range.start + 1,
         ) {
-            torrentEngine.write(resource, range.start, range.endInclusive, this)
+            torrentEngine.stream(hash, season, episode, fileIndex, range.start, range.endInclusive, this)
         }
     }
 

--- a/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/torrent/AndroidJlibtorrentPlaybackEngine.kt
+++ b/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/torrent/AndroidJlibtorrentPlaybackEngine.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withTimeout
 /** Android native packaging for the same streaming engine used by desktop. */
 internal class AndroidJlibtorrentPlaybackEngine(
     private val downloadDirectory: Path,
+    private val lifecycle: TorrentCacheLifecycle,
     private val metadataTimeoutSeconds: Int = 45,
     private val pieceTimeoutMillis: Long = 120_000,
     /** Read fresh each time, so a changed allowance applies without restarting the app. */
@@ -38,6 +39,15 @@ internal class AndroidJlibtorrentPlaybackEngine(
     private val resources = ConcurrentHashMap<String, ManagedResource>()
 
     override suspend fun open(
+        hash: String,
+        season: Int?,
+        episode: Int?,
+        fileIndex: Int?,
+    ): TorrentResource = lifecycle.withUse(hash.lowercase()) {
+        openWithinLease(hash, season, episode, fileIndex)
+    }
+
+    private suspend fun openWithinLease(
         hash: String,
         season: Int?,
         episode: Int?,
@@ -74,6 +84,15 @@ internal class AndroidJlibtorrentPlaybackEngine(
         start: Long,
         endInclusive: Long,
         output: ByteWriteChannel,
+    ) = lifecycle.withUse(resource.id.substringBefore(':').lowercase()) {
+        writeWithinLease(resource, start, endInclusive, output)
+    }
+
+    private suspend fun writeWithinLease(
+        resource: TorrentResource,
+        start: Long,
+        endInclusive: Long,
+        output: ByteWriteChannel,
     ) = withContext(Dispatchers.IO) {
         val managed = resources[resource.id] ?: error("torrent resource is no longer available")
         require(start in 0 until managed.file.size && endInclusive in start until managed.file.size) {
@@ -82,8 +101,8 @@ internal class AndroidJlibtorrentPlaybackEngine(
         var cursor = start
         val buffer = ByteArray(1024 * 1024)
         journal?.touch(managed.torrent.hash)
-        // Pins the torrent for as long as this response is being written, so the retention sweep
-        // cannot release it out from under the player. See the desktop engine.
+        // Kept as a local session guard as well as the cross-component lifecycle lease. The
+        // latter spans Ktor's delayed producer and the eventual filesystem deletion.
         managed.torrent.readers.incrementAndGet()
         try {
             // libtorrent allocates sparsely: until it flushes the first piece covering
@@ -113,6 +132,24 @@ internal class AndroidJlibtorrentPlaybackEngine(
         }
     }
 
+    override suspend fun stream(
+        hash: String,
+        season: Int?,
+        episode: Int?,
+        fileIndex: Int?,
+        start: Long,
+        endInclusive: Long,
+        output: ByteWriteChannel,
+    ) {
+        lifecycle.withUse(hash.lowercase()) {
+            // Ktor invokes its response producer later. Reopening here makes a deletion that won
+            // the gap harmless, while the outer lease keeps this new resource alive through the
+            // complete write.
+            val resource = openWithinLease(hash, season, episode, fileIndex)
+            writeWithinLease(resource, start, endInclusive, output)
+        }
+    }
+
     override fun progress(hash: String): TorrentProgress? {
         val torrent = torrents[hash.lowercase()] ?: return null
         val resource = resources.values.firstOrNull { it.torrent === torrent } ?: return null
@@ -129,13 +166,15 @@ internal class AndroidJlibtorrentPlaybackEngine(
         )
     }
 
-    override fun activeHashes(): Set<String> =
-        torrents.values.filter { it.readers.get() > 0 }.mapTo(mutableSetOf()) { it.hash }
+    override fun activeHashes(): Set<String> = lifecycle.activeHashes()
 
     override fun release(hash: String): Boolean {
         val canonical = hash.lowercase()
         val torrent = torrents[canonical] ?: return true
+        if (canonical in lifecycle.activeHashes()) return false
         if (torrent.readers.get() > 0) return false
+        // The cache service holds the lifecycle's exclusive deletion gate through this removal
+        // and the filesystem delete. A new open waits at that gate, then re-adds a clean torrent.
         torrents.remove(canonical, torrent)
         if (torrent.readers.get() > 0) {
             torrents[canonical] = torrent

--- a/app/backend/src/commonMain/kotlin/com/coveninja/cove/backend/torrent/TorrentPlaybackEngine.kt
+++ b/app/backend/src/commonMain/kotlin/com/coveninja/cove/backend/torrent/TorrentPlaybackEngine.kt
@@ -24,6 +24,27 @@ data class TorrentProgress(
 interface TorrentPlaybackEngine : AutoCloseable {
     suspend fun open(hash: String, season: Int?, episode: Int?, fileIndex: Int?): TorrentResource
     suspend fun write(resource: TorrentResource, start: Long, endInclusive: Long, output: ByteWriteChannel)
+
+    /**
+     * Opens and writes a range when Ktor's delayed response producer actually starts.
+     *
+     * [open] is still called beforehand to build the response headers. A cache sweep may run after
+     * that call but before the producer, so JVM engines override this to reopen and hold one cache
+     * use lease through the complete write. The default keeps lightweight test and non-cache
+     * engines source-compatible.
+     */
+    suspend fun stream(
+        hash: String,
+        season: Int?,
+        episode: Int?,
+        fileIndex: Int?,
+        start: Long,
+        endInclusive: Long,
+        output: ByteWriteChannel,
+    ) {
+        write(open(hash, season, episode, fileIndex), start, endInclusive, output)
+    }
+
     fun progress(hash: String): TorrentProgress?
 
     /**
@@ -48,8 +69,9 @@ interface TorrentPlaybackEngine : AutoCloseable {
      * or frees space the session immediately starts refilling.
      *
      * Returns false if the torrent is being read, in which case the caller must leave it alone.
-     * That check happens here rather than at the call site because only the engine can make it
-     * atomically against a read that is starting at the same moment.
+     * JVM callers additionally hold their shared cache lifecycle's exclusive deletion lease from
+     * before this call until filesystem deletion finishes. That closes the otherwise unavoidable
+     * gap where a new read could start after this method returned.
      */
     fun release(hash: String): Boolean = true
 

--- a/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/LocalBackendRuntime.kt
+++ b/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/LocalBackendRuntime.kt
@@ -34,6 +34,7 @@ import com.coveninja.cove.backend.prefetch.PrefetchService
 import com.coveninja.cove.backend.http.LocalBackendHost
 import com.coveninja.cove.backend.http.MediaBoundary
 import com.coveninja.cove.backend.torrent.JlibtorrentPlaybackEngine
+import com.coveninja.cove.backend.torrent.TorrentCacheLifecycle
 import com.coveninja.cove.backend.platform.DesktopBackendEnvironment
 import com.coveninja.cove.backend.platform.DesktopConfigPaths
 import com.coveninja.cove.shared.data.AppGraph
@@ -207,8 +208,10 @@ class LocalBackendRuntime private constructor(
                 val cachePolicy = MutableStateFlow(
                     runCatching(deviceSettings::read).getOrDefault(TorrentCachePolicy()),
                 )
+                val torrentLifecycle = TorrentCacheLifecycle()
                 val torrentEngine = JlibtorrentPlaybackEngine(
                     downloadDirectory = torrentDirectory,
+                    lifecycle = torrentLifecycle,
                     policy = cachePolicy::value,
                     journal = cacheJournal,
                 )
@@ -219,6 +222,7 @@ class LocalBackendRuntime private constructor(
                             images = imageCacheDirectory,
                             tools = dataDirectory.resolve("tools"),
                         ),
+                        torrentLifecycle = torrentLifecycle,
                         journal = cacheJournal,
                         activeHashes = torrentEngine::activeHashes,
                         release = torrentEngine::release,

--- a/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/http/MediaBoundary.kt
+++ b/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/http/MediaBoundary.kt
@@ -146,7 +146,7 @@ class MediaBoundary(
             status = if (range.partial) HttpStatusCode.PartialContent else HttpStatusCode.OK,
             contentLength = range.endInclusive - range.start + 1,
         ) {
-            engine.write(resource, range.start, range.endInclusive, this)
+            engine.stream(hash, season, episode, fileIndex, range.start, range.endInclusive, this)
         }
     }
 

--- a/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/torrent/JlibtorrentPlaybackEngine.kt
+++ b/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/torrent/JlibtorrentPlaybackEngine.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.sync.withLock
 
 class JlibtorrentPlaybackEngine(
     private val downloadDirectory: Path,
+    private val lifecycle: TorrentCacheLifecycle,
     private val metadataTimeoutSeconds: Int = 45,
     private val pieceTimeoutMillis: Long = 120_000,
     /**
@@ -47,6 +48,15 @@ class JlibtorrentPlaybackEngine(
     private val resources = ConcurrentHashMap<String, ManagedResource>()
 
     override suspend fun open(
+        hash: String,
+        season: Int?,
+        episode: Int?,
+        fileIndex: Int?,
+    ): TorrentResource = lifecycle.withUse(hash.lowercase()) {
+        openWithinLease(hash, season, episode, fileIndex)
+    }
+
+    private suspend fun openWithinLease(
         hash: String,
         season: Int?,
         episode: Int?,
@@ -97,6 +107,15 @@ class JlibtorrentPlaybackEngine(
         start: Long,
         endInclusive: Long,
         output: ByteWriteChannel,
+    ) = lifecycle.withUse(resource.id.substringBefore(':').lowercase()) {
+        writeWithinLease(resource, start, endInclusive, output)
+    }
+
+    private suspend fun writeWithinLease(
+        resource: TorrentResource,
+        start: Long,
+        endInclusive: Long,
+        output: ByteWriteChannel,
     ) = withContext(Dispatchers.IO) {
         val managed = resources[resource.id] ?: error("torrent resource is no longer available")
         require(start in 0 until managed.file.size && endInclusive in start until managed.file.size) {
@@ -107,10 +126,8 @@ class JlibtorrentPlaybackEngine(
         // Dates the cache entry. Cheap by design — it writes memory and flushes at most once a
         // minute — because it sits on the path every served byte takes.
         journal?.touch(managed.torrent.hash)
-        // Marks the torrent as being read for as long as this response is being written, which is
-        // what stops the sweep releasing it underneath the player. Incremented before the first
-        // wait and released in a finally, so an aborted range request — the player seeking, or
-        // closing — does not leave the torrent pinned for the rest of the session.
+        // Kept as a local session guard as well as the cross-component lifecycle lease. The
+        // latter spans Ktor's delayed producer and the eventual filesystem deletion.
         managed.torrent.readers.incrementAndGet()
         try {
             // libtorrent allocates sparsely: until it flushes the first piece covering
@@ -146,6 +163,24 @@ class JlibtorrentPlaybackEngine(
         }
     }
 
+    override suspend fun stream(
+        hash: String,
+        season: Int?,
+        episode: Int?,
+        fileIndex: Int?,
+        start: Long,
+        endInclusive: Long,
+        output: ByteWriteChannel,
+    ) {
+        lifecycle.withUse(hash.lowercase()) {
+            // Ktor invokes its response producer later. Reopening here makes a deletion that won
+            // the gap harmless, while the outer lease keeps this new resource alive through the
+            // complete write.
+            val resource = openWithinLease(hash, season, episode, fileIndex)
+            writeWithinLease(resource, start, endInclusive, output)
+        }
+    }
+
     override suspend fun warmUp() {
         withContext(Dispatchers.IO) { runCatching { session() } }
     }
@@ -167,16 +202,15 @@ class JlibtorrentPlaybackEngine(
         )
     }
 
-    override fun activeHashes(): Set<String> =
-        torrents.values.filter { it.readers.get() > 0 }.mapTo(mutableSetOf()) { it.hash }
+    override fun activeHashes(): Set<String> = lifecycle.activeHashes()
 
     override fun release(hash: String): Boolean {
         val canonical = hash.lowercase()
         val torrent = torrents[canonical] ?: return true
+        if (canonical in lifecycle.activeHashes()) return false
         if (torrent.readers.get() > 0) return false
-        // Removed from the map first: a read that begins between here and the session removal
-        // would otherwise pin a torrent that is already on its way out, and the resource it looks
-        // up would point at files about to be deleted. A new open() after this re-adds it.
+        // The cache service holds the lifecycle's exclusive deletion gate through this removal
+        // and the filesystem delete. A new open waits at that gate, then re-adds a clean torrent.
         torrents.remove(canonical, torrent)
         if (torrent.readers.get() > 0) {
             torrents[canonical] = torrent

--- a/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/http/MediaBoundaryTest.kt
+++ b/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/http/MediaBoundaryTest.kt
@@ -111,6 +111,7 @@ class MediaBoundaryTest {
     @Test
     fun `torrent playback honors a single HTTP byte range`() = runBlocking {
         val payload = "0123456789".encodeToByteArray()
+        var streamed = false
         val engine = object : TorrentPlaybackEngine {
             override suspend fun open(hash: String, season: Int?, episode: Int?, fileIndex: Int?) =
                 TorrentResource("resource", "movie.mkv", payload.size.toLong(), "video/x-matroska")
@@ -121,6 +122,19 @@ class MediaBoundaryTest {
                 endInclusive: Long,
                 output: ByteWriteChannel,
             ) {
+                error("the delayed response producer must reopen through stream")
+            }
+
+            override suspend fun stream(
+                hash: String,
+                season: Int?,
+                episode: Int?,
+                fileIndex: Int?,
+                start: Long,
+                endInclusive: Long,
+                output: ByteWriteChannel,
+            ) {
+                streamed = true
                 val slice = payload.copyOfRange(start.toInt(), endInclusive.toInt() + 1)
                 output.writeFully(slice)
             }
@@ -147,6 +161,7 @@ class MediaBoundaryTest {
             assertEquals("bytes 2-5/10", response.headers[HttpHeaders.ContentRange])
             assertEquals("2345", response.bodyAsText())
         }
+        assertTrue(streamed)
     }
 
     @Test

--- a/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/storage/CacheStorageServiceTest.kt
+++ b/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/storage/CacheStorageServiceTest.kt
@@ -1,15 +1,22 @@
 package com.coveninja.cove.backend.storage
 
+import com.coveninja.cove.backend.torrent.TorrentCacheLifecycle
 import com.coveninja.cove.shared.data.CacheKind
 import com.coveninja.cove.shared.data.TorrentCachePolicy
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import kotlin.io.path.createDirectories
 import kotlin.io.path.writeBytes
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.test.runTest
 
 /**
@@ -41,10 +48,12 @@ class CacheStorageServiceTest {
 
     private fun temporaryRoot(): Path = Files.createTempDirectory("cove-cache-test")
 
+    private fun lifecycle(): TorrentCacheLifecycle = TorrentCacheLifecycle()
+
     @Test
     fun `usage reports each cache separately and omits directories this host lacks`() = runTest {
         val root = temporaryRoot()
-        val usage = CacheStorageService(cache(root)).usage()
+        val usage = CacheStorageService(cache(root), torrentLifecycle = lifecycle()).usage()
         val byKind = usage.entries.associateBy { it.kind }
 
         // Downloads are counted per torrent over the hash directories only. Fails if the walk
@@ -65,7 +74,11 @@ class CacheStorageServiceTest {
     fun `clearing downloads leaves the torrent that is playing and its metadata alone`() = runTest {
         val root = temporaryRoot()
         val directories = cache(root)
-        val service = CacheStorageService(directories, activeHashes = { setOf(hashA) })
+        val service = CacheStorageService(
+            directories,
+            torrentLifecycle = lifecycle(),
+            activeHashes = { setOf(hashA) },
+        )
 
         val result = service.clear(CacheKind.TorrentDownloads)
 
@@ -86,7 +99,11 @@ class CacheStorageServiceTest {
     fun `an active hash is matched whatever case it is reported in`() = runTest {
         val root = temporaryRoot()
         val directories = cache(root)
-        val service = CacheStorageService(directories, activeHashes = { setOf(hashA.uppercase()) })
+        val service = CacheStorageService(
+            directories,
+            torrentLifecycle = lifecycle(),
+            activeHashes = { setOf(hashA.uppercase()) },
+        )
 
         service.clear(CacheKind.TorrentDownloads)
 
@@ -117,7 +134,12 @@ class CacheStorageServiceTest {
             directories.torrents!!.resolve(hashA),
             java.nio.file.attribute.FileTime.fromMillis(2_000),
         )
-        val service = CacheStorageService(directories, journal = journal, clock = { 3_000L })
+        val service = CacheStorageService(
+            directories,
+            torrentLifecycle = lifecycle(),
+            journal = journal,
+            clock = { 3_000L },
+        )
 
         service.enforce(TorrentCachePolicy(limitBytes = 4_000))
 
@@ -138,7 +160,12 @@ class CacheStorageServiceTest {
         val now = 1_800_000_000_000
         val journal = TorrentCacheJournal(directories.torrents!!) { now }
 
-        CacheStorageService(directories, journal = journal, clock = { now })
+        CacheStorageService(
+            directories,
+            torrentLifecycle = lifecycle(),
+            journal = journal,
+            clock = { now },
+        )
             .enforce(TorrentCachePolicy(maxAgeDays = 30))
 
         // The upgrade case, and the one that would cost a viewer gigabytes without warning:
@@ -157,7 +184,8 @@ class CacheStorageServiceTest {
         val root = temporaryRoot()
         val directories = cache(root)
 
-        val result = CacheStorageService(directories).enforce(TorrentCachePolicy())
+        val result = CacheStorageService(directories, torrentLifecycle = lifecycle())
+            .enforce(TorrentCachePolicy())
 
         // The default on a host that has never opened the storage screen. Fails if an unset
         // limit reads as a limit of zero, which would delete every download at first launch.
@@ -173,6 +201,7 @@ class CacheStorageServiceTest {
         val refused = mutableListOf<String>()
         val service = CacheStorageService(
             directories = directories,
+            torrentLifecycle = lifecycle(),
             // Nothing is reported as being read, but the engine declines when actually asked —
             // the race the gate exists for, where playback starts between the sweep choosing a
             // torrent and reaching it.
@@ -192,6 +221,43 @@ class CacheStorageServiceTest {
     }
 
     @Test
+    fun `a new stream cannot enter between session release and file deletion`() = runTest {
+        val root = temporaryRoot()
+        val torrents = root.resolve("torrents")
+        val torrent = torrents.resolve(hashA)
+        torrent.createDirectories()
+        torrent.resolve("episode.mkv").writeBytes(ByteArray(4_000))
+        val lifecycle = lifecycle()
+        val releaseStarted = CountDownLatch(1)
+        val allowReleaseToFinish = CountDownLatch(1)
+        val useEntered = CompletableDeferred<Unit>()
+        val service = CacheStorageService(
+            directories = CacheDirectories(torrents = torrents),
+            torrentLifecycle = lifecycle,
+            release = {
+                releaseStarted.countDown()
+                check(allowReleaseToFinish.await(5, TimeUnit.SECONDS))
+                true
+            },
+        )
+
+        val clear = async(Dispatchers.Default) { service.clear(CacheKind.TorrentDownloads) }
+        assertTrue(releaseStarted.await(5, TimeUnit.SECONDS))
+        val newUse = async(start = CoroutineStart.UNDISPATCHED) {
+            lifecycle.withUse(hashA) {
+                assertFalse(Files.exists(torrent))
+                useEntered.complete(Unit)
+            }
+        }
+        assertFalse(useEntered.isCompleted)
+
+        allowReleaseToFinish.countDown()
+        assertEquals(4_000, clear.await().freedBytes)
+        newUse.await()
+        assertTrue(useEntered.isCompleted)
+    }
+
+    @Test
     fun `the sweep releases a torrent from the session before deleting it`() = runTest {
         val root = temporaryRoot()
         val directories = cache(root)
@@ -202,6 +268,7 @@ class CacheStorageServiceTest {
 
         CacheStorageService(
             directories = directories,
+            torrentLifecycle = lifecycle(),
             journal = journal,
             release = { released += it; true },
             clock = { 1_000L },
@@ -224,7 +291,12 @@ class CacheStorageServiceTest {
         journal.touch(hashB)
         journal.flush()
 
-        CacheStorageService(directories, journal = journal, activeHashes = { setOf(hashA) })
+        CacheStorageService(
+            directories,
+            torrentLifecycle = lifecycle(),
+            journal = journal,
+            activeHashes = { setOf(hashA) },
+        )
             .clear(CacheKind.TorrentDownloads)
 
         val reloaded = TorrentCacheJournal(directories.torrents!!)

--- a/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/storage/LocalStorageRepositoryTest.kt
+++ b/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/storage/LocalStorageRepositoryTest.kt
@@ -1,6 +1,7 @@
 package com.coveninja.cove.backend.storage
 
 import com.coveninja.cove.backend.platform.DeviceSettingsService
+import com.coveninja.cove.backend.torrent.TorrentCacheLifecycle
 import com.coveninja.cove.shared.data.CacheKind
 import com.coveninja.cove.shared.data.DevicePerformanceState
 import com.coveninja.cove.shared.data.StorageUsageState
@@ -41,6 +42,7 @@ class LocalStorageRepositoryTest {
         val policy = MutableStateFlow(settings.read())
         val service = CacheStorageService(
             directories = CacheDirectories(torrents = root.resolve("torrents")),
+            torrentLifecycle = TorrentCacheLifecycle(),
             journal = TorrentCacheJournal(root.resolve("torrents")),
         )
         return LocalStorageRepository(service, settings, policy) to policy

--- a/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/torrent/TorrentCacheLifecycleTest.kt
+++ b/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/torrent/TorrentCacheLifecycleTest.kt
@@ -1,0 +1,100 @@
+package com.coveninja.cove.backend.torrent
+
+import java.util.Collections
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
+
+class TorrentCacheLifecycleTest {
+    private val hash = "a".repeat(40)
+
+    @Test
+    fun `a use lease makes deletion fail closed regardless of hash case`() = runTest {
+        val lifecycle = TorrentCacheLifecycle()
+        var deletionRan = false
+
+        lifecycle.withUse(hash.uppercase()) {
+            assertEquals(setOf(hash), lifecycle.activeHashes())
+            assertFalse(lifecycle.tryDelete(hash) {
+                deletionRan = true
+                true
+            })
+            assertFalse(deletionRan)
+        }
+
+        assertTrue(lifecycle.activeHashes().isEmpty())
+        assertTrue(lifecycle.tryDelete(hash) {
+            deletionRan = true
+            true
+        })
+        assertTrue(deletionRan)
+    }
+
+    @Test
+    fun `a new use waits until deletion has completely finished`() = runTest {
+        val lifecycle = TorrentCacheLifecycle()
+        val deletionStarted = CountDownLatch(1)
+        val allowDeletionToFinish = CountDownLatch(1)
+        val useEntered = CompletableDeferred<Unit>()
+        val order = Collections.synchronizedList(mutableListOf<String>())
+
+        val deletion = async(Dispatchers.Default) {
+            lifecycle.tryDelete(hash) {
+                deletionStarted.countDown()
+                check(allowDeletionToFinish.await(5, TimeUnit.SECONDS))
+                order += "delete finished"
+                true
+            }
+        }
+        assertTrue(deletionStarted.await(5, TimeUnit.SECONDS))
+
+        val use = async(start = CoroutineStart.UNDISPATCHED) {
+            lifecycle.withUse(hash) {
+                order += "use entered"
+                useEntered.complete(Unit)
+            }
+        }
+        assertFalse(useEntered.isCompleted)
+
+        allowDeletionToFinish.countDown()
+        assertTrue(deletion.await())
+        use.await()
+        assertEquals(listOf("delete finished", "use entered"), order)
+    }
+
+    @Test
+    fun `a failed use always releases its lease`() = runTest {
+        val lifecycle = TorrentCacheLifecycle()
+
+        val failure = runCatching {
+            lifecycle.withUse(hash) { error("failed stream") }
+        }.exceptionOrNull()
+
+        assertIs<IllegalStateException>(failure)
+        assertTrue(lifecycle.activeHashes().isEmpty())
+        assertTrue(lifecycle.tryDelete(hash) { true })
+    }
+
+    @Test
+    fun `a failed deletion always lets later users proceed`() = runTest {
+        val lifecycle = TorrentCacheLifecycle()
+
+        val failure = runCatching {
+            lifecycle.tryDelete(hash) { error("failed deletion") }
+        }.exceptionOrNull()
+        var entered = false
+        lifecycle.withUse(hash) { entered = true }
+
+        assertIs<IllegalStateException>(failure)
+        assertTrue(entered)
+    }
+}

--- a/app/backend/src/jvmSharedMain/kotlin/com/coveninja/cove/backend/storage/CacheStorageService.kt
+++ b/app/backend/src/jvmSharedMain/kotlin/com/coveninja/cove/backend/storage/CacheStorageService.kt
@@ -1,5 +1,6 @@
 package com.coveninja.cove.backend.storage
 
+import com.coveninja.cove.backend.torrent.TorrentCacheLifecycle
 import com.coveninja.cove.shared.data.CacheEntry
 import com.coveninja.cove.shared.data.CacheKind
 import com.coveninja.cove.shared.data.ClearResult
@@ -24,10 +25,11 @@ import kotlinx.coroutines.withContext
  */
 class CacheStorageService(
     private val directories: CacheDirectories,
+    private val torrentLifecycle: TorrentCacheLifecycle,
     private val journal: TorrentCacheJournal? = null,
     private val activeHashes: () -> Set<String> = { emptySet() },
     /**
-     * Drops a torrent from the peer session, refusing while it is being read.
+     * Drops a torrent from the peer session while [torrentLifecycle] owns its deletion gate.
      *
      * Deleting the files of a torrent libtorrent still holds is not a deletion: the handle keeps
      * the file open and the session carries on writing pieces into it, so the space comes back
@@ -109,13 +111,24 @@ class CacheStorageService(
         val removed = mutableListOf<String>()
         for (torrent in torrents) {
             if (!isDeletableTorrentDirectory(root, torrent.path)) continue
-            // The last word on whether this is safe, and it is the engine's rather than the
-            // plan's: a read can begin between the sweep choosing a torrent and reaching it.
-            if (!runCatching { release(torrent.hash) }.getOrDefault(false)) continue
-            freed += deleteTree(torrent.path)
-            removed += torrent.hash
-            // Metadata is a few kilobytes and saves a DHT lookup on the next play, so it outlives
-            // the content it describes on purpose — clearing it is its own row on the screen.
+            // The plan's active snapshot is advisory: a read can begin after it. This exclusive
+            // gate is the last word and spans both peer-session removal and filesystem deletion,
+            // so a new stream either wins first (and this sweep skips it) or waits and reopens
+            // after the old files are completely gone.
+            runCatching {
+                torrentLifecycle.tryDelete(torrent.hash) {
+                    if (!runCatching { release(torrent.hash) }.getOrDefault(false)) {
+                        false
+                    } else {
+                        freed += deleteTree(torrent.path)
+                        removed += torrent.hash
+                        // Metadata is a few kilobytes and saves a DHT lookup on the next play, so
+                        // it outlives the content it describes on purpose — clearing it is its own
+                        // row on the screen.
+                        true
+                    }
+                }
+            }
         }
         journal?.forget(removed)
         return freed
@@ -198,7 +211,8 @@ class CacheStorageService(
     }
 
     private fun canonicalActiveHashes(): Set<String> =
-        runCatching { activeHashes() }.getOrDefault(emptySet()).mapTo(mutableSetOf()) { it.lowercase() }
+        (runCatching { activeHashes() }.getOrDefault(emptySet()) + torrentLifecycle.activeHashes())
+            .mapTo(mutableSetOf()) { it.lowercase() }
 
     private fun freeSpace(): Long {
         val probe = CacheKind.entries

--- a/app/backend/src/jvmSharedMain/kotlin/com/coveninja/cove/backend/torrent/TorrentCacheLifecycle.kt
+++ b/app/backend/src/jvmSharedMain/kotlin/com/coveninja/cove/backend/torrent/TorrentCacheLifecycle.kt
@@ -1,0 +1,96 @@
+package com.coveninja.cove.backend.torrent
+
+import kotlinx.coroutines.CompletableDeferred
+
+/**
+ * Coordinates torrent use with irreversible cache deletion.
+ *
+ * A use lease may span coroutine suspension and may finish on another thread. Deletion therefore
+ * cannot use a thread-owned read/write lock. Instead, the small state transition is synchronized
+ * and a coroutine arriving during deletion awaits its completion without blocking a thread.
+ *
+ * Deletion is deliberately try-only: a retention sweep skips a torrent that is already in use.
+ * Once deletion starts, however, new users wait until both the peer-session handle and its files
+ * have been removed, then reopen the torrent from a clean state.
+ */
+class TorrentCacheLifecycle {
+    private val monitor = Any()
+    private val states = mutableMapOf<String, State>()
+
+    suspend fun <T> withUse(hash: String, action: suspend () -> T): T {
+        val canonical = hash.lowercase()
+        acquireUse(canonical)
+        return try {
+            action()
+        } finally {
+            releaseUse(canonical)
+        }
+    }
+
+    /**
+     * Runs [action] exclusively against every [withUse] block for [hash].
+     *
+     * Returns false without running [action] when the torrent is already in use or another
+     * deletion owns it. While [action] runs, new users suspend until its `finally` completes.
+     */
+    fun tryDelete(hash: String, action: () -> Boolean): Boolean {
+        val canonical = hash.lowercase()
+        val finished = CompletableDeferred<Unit>()
+        synchronized(monitor) {
+            val state = states.getOrPut(canonical, ::State)
+            if (state.deleting || state.users > 0) return false
+            state.deleting = true
+            state.deletionFinished = finished
+        }
+        return try {
+            action()
+        } finally {
+            synchronized(monitor) {
+                val state = states[canonical]
+                if (state?.deletionFinished === finished) {
+                    state.deleting = false
+                    state.deletionFinished = null
+                    if (state.users == 0) states.remove(canonical, state)
+                }
+            }
+            finished.complete(Unit)
+        }
+    }
+
+    fun activeHashes(): Set<String> = synchronized(monitor) {
+        states.filterValues { it.users > 0 }.keys.toSet()
+    }
+
+    private suspend fun acquireUse(hash: String) {
+        while (true) {
+            var acquired = false
+            val waitFor = synchronized(monitor) {
+                val state = states.getOrPut(hash, ::State)
+                if (!state.deleting) {
+                    state.users += 1
+                    acquired = true
+                    null
+                } else {
+                    checkNotNull(state.deletionFinished)
+                }
+            }
+            if (acquired) return
+            checkNotNull(waitFor).await()
+        }
+    }
+
+    private fun releaseUse(hash: String) {
+        synchronized(monitor) {
+            val state = checkNotNull(states[hash]) { "torrent use lease was not registered" }
+            check(state.users > 0) { "torrent use lease was released twice" }
+            state.users -= 1
+            if (state.users == 0 && !state.deleting) states.remove(hash, state)
+        }
+    }
+
+    private class State {
+        var users: Int = 0
+        var deleting: Boolean = false
+        var deletionFinished: CompletableDeferred<Unit>? = null
+    }
+}


### PR DESCRIPTION
## Summary

- Hold a shared per-torrent lifecycle lease across the complete HTTP open-and-stream operation.
- Make torrent session release and cache-file deletion mutually exclusive with active streams on desktop and Android.
- Add deterministic concurrency tests for deletion/use exclusion and the delayed response-producer path.

This closes the race where Ktor created response headers before its delayed body producer ran, allowing a concurrent cache sweep to remove the torrent session and files underneath an active response.

## Behavior and migration impact

- Active streams prevent cache deletion; deletion blocks new streams until session removal and filesystem deletion finish.
- No schema or data migration.

## Testing

- `./gradlew :backend:desktopTest` — 160 passed, 0 failed
- `git diff --check origin/master...fork/fix/cache-lifecycle-race`