### PR TITLE
fix: prevent CoreAudio hotplug use-after-free on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,13 @@ jobs:
           distribution: temurin
           java-version: '21'
       - uses: gradle/actions/setup-gradle@v6
-      - name: Install libmpv
-        run: brew install mpv
+      - name: Install native mpv build dependencies
+        run: brew install mpv meson ninja
+      - name: Build libmpv with the CoreAudio hotplug lifetime fix
+        run: scripts/build-patched-mpv-macos.sh "$RUNNER_TEMP/cove-mpv"
       - name: Test and build Apple-silicon application
+        env:
+          COVE_MPV_LIBRARY_DIR: ${{ runner.temp }}/cove-mpv/lib
         run: >-
           scripts/gradle-retry.sh
           :backend:desktopTest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,7 +264,9 @@ jobs:
           java-version: '21'
       - uses: gradle/actions/setup-gradle@v6
       - name: Install native packaging dependencies
-        run: brew install mpv dylibbundler
+        run: brew install mpv dylibbundler meson ninja
+      - name: Build libmpv with the CoreAudio hotplug lifetime fix
+        run: scripts/build-patched-mpv-macos.sh "$RUNNER_TEMP/cove-mpv"
       - name: Build Compose application
         env:
           UPDATE_PUBLIC_KEYS: ${{ needs.update-key.outputs.public_keys }}
@@ -280,7 +282,7 @@ jobs:
           APP=app/desktop/build/compose/binaries/main/app/Cove.app
           FRAMEWORKS="$APP/Contents/Frameworks"
           mkdir -p "$FRAMEWORKS"
-          cp "$(brew --prefix mpv)/lib/libmpv.2.dylib" "$FRAMEWORKS/libmpv.2.dylib"
+          cp "$RUNNER_TEMP/cove-mpv/lib/libmpv.2.dylib" "$FRAMEWORKS/libmpv.2.dylib"
           dylibbundler -of -cd -b -x "$FRAMEWORKS/libmpv.2.dylib" \
             -d "$FRAMEWORKS" -p '@loader_path/'
           # Homebrew's libmpv already carries this rpath. dylibbundler adds it

--- a/packaging/macos/mpv-coreaudio-hotplug-lifetime.patch
+++ b/packaging/macos/mpv-coreaudio-hotplug-lifetime.patch
@@ -1,0 +1,178 @@
+diff --git a/audio/out/ao_coreaudio.c b/audio/out/ao_coreaudio.c
+index 4b4bf1d..22856e4 100644
+--- a/audio/out/ao_coreaudio.c
++++ b/audio/out/ao_coreaudio.c
+@@ -28,12 +28,35 @@
+ #include "ao_coreaudio_properties.h"
+ #include "ao_coreaudio_utils.h"
+ #include "osdep/mac/compat.h"
++#include "osdep/threads.h"
+ 
+ // The timeout for stopping the audio unit after being reset. This allows the
+ // device to sleep after playback paused. The duration is chosen to match the
+ // behavior of AVFoundation.
+ #define IDLE_TIME 7 * NSEC_PER_SEC
+ 
++// CoreAudio dispatches device hotplug notifications (kAudioHardwareProperty
++// Devices/DefaultOutputDevice) asynchronously on its own internal queue, so
++// hotplug_cb() can still be entered (or be running) after the owning `ao` has
++// been uninit'd and freed: AudioObjectRemovePropertyListener() does not
++// guarantee that an already-queued notification is cancelled. Seen as a SIGSEGV
++// inside the callback on macOS 26/27, where device-change notifications fire
++// far more often (in particular after wake from sleep).
++//
++// The listener context is heap-allocated, decoupled from `ao`'s talloc
++// lifetime, and intentionally never freed, so a late callback can always
++// safely read `valid`. `valid` is guarded by hotplug_lock rather than being
++// merely atomic: a plain atomic check is a TOCTOU, since teardown can still
++// complete between the check and the dereference of `ao`. Taking the lock in
++// unregister_hotplug_cb() also waits out a callback that already passed the
++// check, so once unregister_hotplug_cb() returns, no callback can touch `ao`.
++struct coreaudio_hotplug_ctx {
++    struct ao *ao;
++    bool valid; // hotplug_lock
++};
++
++static mp_static_mutex hotplug_lock = MP_STATIC_MUTEX_INITIALIZER;
++
+ struct priv {
+     // This must be put in the front
+     struct coreaudio_cb_sem sem;
+@@ -53,6 +76,7 @@ struct priv {
+     dispatch_queue_t queue;
+ 
+     int hotplug_cb_registration_times;
++    struct coreaudio_hotplug_ctx *hotplug_ctx;
+ };
+ 
+ static int64_t ca_get_hardware_latency(struct ao *ao) {
+@@ -196,6 +220,16 @@ static int init(struct ao *ao)
+     return CONTROL_OK;
+ 
+ coreaudio_error:
++    // The hotplug listener is registered early in init(), but ao_uninit() only
++    // calls the driver's uninit() (and thus unregister_hotplug_cb()) when
++    // init() succeeded, i.e. once ao->driver_initialized is set. Failing here
++    // without unregistering would leave the CoreAudio listener installed for
++    // good, pointing at an `ao` that ao_init() frees on its way out - the next
++    // device change then runs hotplug_cb() on freed memory. This is the common
++    // case on macOS 26/27, where coreaudio init regularly fails and the player
++    // silently falls back to another ao (e.g. --ao=coreaudio,avfoundation).
++    if (p->hotplug_cb_registration_times)
++        unregister_hotplug_cb(ao);
+     return CONTROL_ERROR;
+ }
+ 
+@@ -457,15 +491,29 @@ static void uninit(struct ao *ao)
+ 
+ static OSStatus hotplug_cb(AudioObjectID id, UInt32 naddr,
+                            const AudioObjectPropertyAddress addr[],
+-                           void *ctx)
++                           void *ctx_ptr)
+ {
+-    struct ao *ao = ctx;
++    struct coreaudio_hotplug_ctx *ctx = ctx_ptr;
++
++    // Held for the whole callback: the listener may be torn down concurrently
++    // by unregister_hotplug_cb(), and `ao` can be freed as soon as that
++    // returns. See the comment on struct coreaudio_hotplug_ctx.
++    mp_mutex_lock(&hotplug_lock);
++
++    if (!ctx->valid) {
++        mp_mutex_unlock(&hotplug_lock);
++        return noErr;
++    }
++
++    struct ao *ao = ctx->ao;
+     struct priv *p = ao->priv;
+     MP_VERBOSE(ao, "Handling potential hotplug event...\n");
+     reinit_device(ao);
+     if (p->audio_unit)
+         reinit_latency(ao);
+     ao_hotplug_event(ao);
++
++    mp_mutex_unlock(&hotplug_lock);
+     return noErr;
+ }
+ 
+@@ -497,15 +545,27 @@ static bool register_hotplug_cb(struct ao *ao)
+     if (p->hotplug_cb_registration_times++)
+         return true;
+ 
++    // Deliberately not tied to `p`/`ao`'s talloc lifetime and never freed:
++    // see the comment on struct coreaudio_hotplug_ctx.
++    p->hotplug_ctx = calloc(1, sizeof(*p->hotplug_ctx));
++    if (!p->hotplug_ctx) {
++        p->hotplug_cb_registration_times--;
++        MP_ERR(ao, "failed to allocate hotplug listener context\n");
++        return false;
++    }
++    p->hotplug_ctx->ao = ao;
++    p->hotplug_ctx->valid = true;
++
+     OSStatus err = noErr;
+-    for (int i = 0; i < MP_ARRAY_SIZE(hotplug_properties); i++) {
++    int i;
++    for (i = 0; i < MP_ARRAY_SIZE(hotplug_properties); i++) {
+         AudioObjectPropertyAddress addr = {
+             hotplug_properties[i],
+             kAudioObjectPropertyScopeGlobal,
+             kAudioObjectPropertyElementMain
+         };
+         err = AudioObjectAddPropertyListener(
+-            kAudioObjectSystemObject, &addr, hotplug_cb, (void *)ao);
++            kAudioObjectSystemObject, &addr, hotplug_cb, p->hotplug_ctx);
+         if (err != noErr) {
+             char *c1 = mp_tag_str(hotplug_properties[i]);
+             char *c2 = mp_tag_str(err);
+@@ -517,6 +577,23 @@ static bool register_hotplug_cb(struct ao *ao)
+     return true;
+ 
+ coreaudio_error:
++    // Roll back the listeners registered so far and invalidate the context:
++    // both callers (init(), hotplug_init()) let the `ao` be freed when this
++    // fails, and neither gets a matching uninit()/hotplug_uninit() call, so a
++    // listener left behind here would outlive the `ao` for good.
++    for (int j = 0; j < i; j++) {
++        AudioObjectPropertyAddress addr = {
++            hotplug_properties[j],
++            kAudioObjectPropertyScopeGlobal,
++            kAudioObjectPropertyElementMain
++        };
++        AudioObjectRemovePropertyListener(
++            kAudioObjectSystemObject, &addr, hotplug_cb, p->hotplug_ctx);
++    }
++    mp_mutex_lock(&hotplug_lock);
++    p->hotplug_ctx->valid = false;
++    mp_mutex_unlock(&hotplug_lock);
++    p->hotplug_cb_registration_times--;
+     return false;
+ }
+ 
+@@ -527,6 +604,17 @@ static void unregister_hotplug_cb(struct ao *ao)
+     if (--p->hotplug_cb_registration_times)
+         return;
+ 
++    if (!p->hotplug_ctx)
++        return;
++
++    // Invalidate before removing the listener. Acquiring the lock also waits
++    // for a callback that is already past its `valid` check and running with
++    // this `ao`, so that once this function returns - and the ao is freed -
++    // no callback can be touching it any more.
++    mp_mutex_lock(&hotplug_lock);
++    p->hotplug_ctx->valid = false;
++    mp_mutex_unlock(&hotplug_lock);
++
+     OSStatus err = noErr;
+     for (int i = 0; i < MP_ARRAY_SIZE(hotplug_properties); i++) {
+         AudioObjectPropertyAddress addr = {
+@@ -535,7 +623,7 @@ static void unregister_hotplug_cb(struct ao *ao)
+             kAudioObjectPropertyElementMain
+         };
+         err = AudioObjectRemovePropertyListener(
+-            kAudioObjectSystemObject, &addr, hotplug_cb, (void *)ao);
++            kAudioObjectSystemObject, &addr, hotplug_cb, p->hotplug_ctx);
+         if (err != noErr) {
+             char *c1 = mp_tag_str(hotplug_properties[i]);
+             char *c2 = mp_tag_str(err);

--- a/scripts/build-patched-mpv-macos.sh
+++ b/scripts/build-patched-mpv-macos.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "This script builds Cove's patched macOS libmpv." >&2
+  exit 1
+fi
+
+install_prefix=${1:?"usage: $0 INSTALL_PREFIX"}
+script_dir=$(cd "$(dirname "$0")" && pwd)
+repo_root=$(cd "$script_dir/.." && pwd)
+patch_file="$repo_root/packaging/macos/mpv-coreaudio-hotplug-lifetime.patch"
+mpv_version=0.41.0
+mpv_sha256=ee21092a5ee427353392360929dc64645c54479aefdb5babc5cfbb5fad626209
+build_root=$(mktemp -d "${TMPDIR:-/tmp}/cove-mpv-build.XXXXXX")
+
+cleanup() {
+  rm -rf "$build_root"
+}
+trap cleanup EXIT
+
+archive="$build_root/mpv-$mpv_version.tar.gz"
+source_dir="$build_root/mpv-$mpv_version"
+build_dir="$build_root/build"
+
+# Homebrew keeps libarchive keg-only, so pkg-config cannot find it through the
+# normal prefix. mpv links it for archive-backed media and expects its .pc file.
+libarchive_pkgconfig="$(brew --prefix libarchive)/lib/pkgconfig"
+export PKG_CONFIG_PATH="$libarchive_pkgconfig${PKG_CONFIG_PATH:+:$PKG_CONFIG_PATH}"
+
+curl --fail --location --retry 3 \
+  --output "$archive" \
+  "https://github.com/mpv-player/mpv/archive/refs/tags/v$mpv_version.tar.gz"
+
+actual_sha256=$(shasum -a 256 "$archive" | awk '{print $1}')
+if [[ "$actual_sha256" != "$mpv_sha256" ]]; then
+  echo "mpv source checksum mismatch: expected $mpv_sha256, got $actual_sha256" >&2
+  exit 1
+fi
+
+tar -xzf "$archive" -C "$build_root"
+(
+  cd "$source_dir"
+  git apply --check "$patch_file"
+  git apply "$patch_file"
+)
+
+meson setup "$build_dir" "$source_dir" \
+  --prefix="$install_prefix" \
+  --libdir=lib \
+  --buildtype=release \
+  -Dbuild-date=false \
+  -Dcplayer=false \
+  -Dhtml-build=disabled \
+  -Djavascript=enabled \
+  -Dlibarchive=enabled \
+  -Dlibmpv=true \
+  -Dlua=luajit \
+  -Dmanpage-build=disabled \
+  -Duchardet=enabled \
+  -Dvapoursynth=disabled \
+  -Dvulkan=enabled
+meson compile -C "$build_dir" --verbose
+meson install -C "$build_dir"
+
+test -f "$install_prefix/lib/libmpv.2.dylib"


### PR DESCRIPTION
## Summary

- patch mpv 0.41.0 at source so late CoreAudio hotplug callbacks cannot dereference a freed audio-output object
- build the pinned, checksum-verified patched libmpv in macOS pull-request CI and release packaging
- bundle and ad-hoc sign the patched library and its native dependency closure in the macOS DMG
- keep Linux, Windows, and Android on their native libmpv builds because ao_coreaudio.c is macOS-only

## Root cause

mpv registers hotplug_cb with a raw ao pointer. CoreAudio can deliver an already-queued device-change notification after teardown, so the callback enters mp_msg through freed state and crashes with SIGSEGV; the JVM then reports the native failure as SIGABRT. The source patch gives the listener a lifetime-independent context, guards validity and the ao dereference with a mutex, waits out an in-flight callback during teardown, and rolls back listeners when initialization fails.

Tracked upstream in mpv-player/mpv#18274. The included patch matches the linked MPVKit community fix and can be removed once upstream ships an equivalent fix.

## Verification

- fresh checksum-verified mpv 0.41.0 source build completed successfully on Apple silicon
- actionlint passed for ci.yml and release.yml
- macOS CI task set passed: backend desktop tests, UI desktop tests, desktop tests, and createDistributable
- resulting app passed deep code-sign verification
- all 48 bundled dylibs have 0 Homebrew dependency paths, 0 non-system external paths, and 0 unresolved loader-path dependencies
- mounted-DMG smoke test loaded Cove.app/Contents/Frameworks/libmpv.2.dylib with no library override, initialized CoreAudio playback, and exited cleanly
- patched build completed 2,000 player create/play/teardown lifecycles while a 2,500-cycle CoreAudio device churn run also completed

## Remaining runtime limit

The synthetic device churn is nondeterministic and the stock library also survived it, so it proves packaging and stability rather than deterministically reproducing the original race. The source lifetime ordering and the mounted release artifact are verified; an actual macOS 27 device removal or wake event remains the final soak confirmation.