### PR TITLE
chore: compile against Android SDK 37

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null || true
           "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
-            "platforms;android-36" "build-tools;36.0.0"
+            "platforms;android-37.0" "build-tools;37.0.0"
       - name: Build and test
         run: >-
           scripts/gradle-retry.sh
@@ -130,7 +130,7 @@ jobs:
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null || true
           "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
-            "platforms;android-36" "build-tools;36.0.0"
+            "platforms;android-37.0" "build-tools;37.0.0"
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null || true
           "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
-            "platforms;android-36" "build-tools;36.0.0"
+            "platforms;android-37.0" "build-tools;37.0.0"
       - name: Build and test
         env:
           UPDATE_PUBLIC_KEYS: ${{ needs.update-key.outputs.public_keys }}
@@ -350,7 +350,7 @@ jobs:
         run: |
           yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses > /dev/null || true
           "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" \
-            "platforms;android-36" "build-tools;36.0.0"
+            "platforms;android-37.0" "build-tools;37.0.0"
       - name: Decode release keystore
         env:
           KEYSTORE: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}

--- a/app/backend/build.gradle.kts
+++ b/app/backend/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
     jvm("desktop")
     android {
         namespace = "com.coveninja.cove.backend"
-        compileSdk = 36
+        compileSdk = 37
         minSdk = 28
         withHostTest {}
         compilerOptions {

--- a/app/benchmark/build.gradle.kts
+++ b/app/benchmark/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 
 android {
     namespace = "com.coveninja.cove.benchmark"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 28

--- a/app/mobile/build.gradle.kts
+++ b/app/mobile/build.gradle.kts
@@ -52,7 +52,7 @@ fun semanticVersionCode(version: String): Int = version.split('.')
 
 android {
     namespace = "com.coveninja.cove"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.coveninja.cove"

--- a/app/shared/build.gradle.kts
+++ b/app/shared/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
 
     android {
         namespace = "com.coveninja.cove.shared"
-        compileSdk = 36
+        compileSdk = 37
         minSdk = 28
 
         withHostTest {}

--- a/app/ui/build.gradle.kts
+++ b/app/ui/build.gradle.kts
@@ -23,7 +23,7 @@ kotlin {
     jvm("desktop")
     android {
         namespace = "com.coveninja.cove.ui"
-        compileSdk = 36
+        compileSdk = 37
         minSdk = 28
         compilerOptions {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21)


### PR DESCRIPTION
Unblocks the weekly Dependabot group (#54), which currently fails CI at
`:mobile:checkDebugAarMetadata`:

> Dependency 'androidx.core:core-ktx:1.19.0' requires libraries and applications
> that depend on it to compile against version 37 or later of the Android APIs.
> `:mobile` is currently compiled against android-36.

Bumps `compileSdk` to 37 in the five Android-targeting modules and points the four
`sdkmanager` steps in `ci.yml`/`release.yml` at the matching platform.

### Notes

- The SDK package is named `platforms;android-37.0` — there is **no** bare
  `platforms;android-37` — so the workflow steps name the minor explicitly.
  AGP 9.3.1 resolves `compileSdk = 37` to that platform on its own, so no
  `compileSdkMinor` is needed in the build files.
- `targetSdk` stays at 36. That opts the app in to new *runtime* behaviour and is a
  separate, riskier decision from what we compile against.
- Two of the four workflow edits (`release.yml:79`, `:353`) only ever run on a tag
  push, so `make test-release` was run to rehearse them.

### Verified locally

- `:mobile:compileDebugKotlin` — compileSdk 37 resolves against `android-37.0`
- `:mobile:lintDebug` — clean, no new findings from the SDK bump
- `:mobile:checkDebugAarMetadata` with androidx-core temporarily at 1.19.0 — passes,
  confirming this actually unblocks #54
- `make test` — green
- `make test-release` — release dry run passes
- `:mobile:assembleDebug` — builds