### PR TITLE
fix: torrent playback no longer pays two cold starts on Android

### DIFF
--- a/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/playback/AndroidPlaybackMediaHost.kt
+++ b/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/playback/AndroidPlaybackMediaHost.kt
@@ -190,7 +190,18 @@ internal class AndroidPlaybackMediaHost private constructor(
         episode: Int?,
         fileIndex: Int?,
     ) {
-        val resource = torrentEngine.open(hash, season, episode, fileIndex)
+        // The player only ever says "The selected stream could not be opened", which is the
+        // same sentence whether the hash was rejected, the swarm was empty or the file never
+        // appeared. The reason is worth one line on the way past — see the stream producer
+        // below for why nothing else records it.
+        val resource = try {
+            torrentEngine.open(hash, season, episode, fileIndex)
+        } catch (failure: Throwable) {
+            System.err.println(
+                "Cove torrent: open failed for $hash — ${failure::class.simpleName}: ${failure.message}",
+            )
+            throw failure
+        }
         val range = parseRange(call.request.header(HttpHeaders.Range), resource.length)
         call.response.header(HttpHeaders.AcceptRanges, "bytes")
         call.response.header(
@@ -208,7 +219,30 @@ internal class AndroidPlaybackMediaHost private constructor(
             status = if (range.partial) HttpStatusCode.PartialContent else HttpStatusCode.OK,
             contentLength = range.endInclusive - range.start + 1,
         ) {
-            torrentEngine.stream(hash, season, episode, fileIndex, range.start, range.endInclusive, this)
+            // A failure here arrives after the 206 has already gone out, so it cannot become an
+            // error response — the connection just dies and the player reports a stream it could
+            // not open. Ktor hands the cause to an SLF4J logger, and this process binds no
+            // provider ("No SLF4J providers were found" at startup), so by default the one
+            // account of what went wrong is discarded. That is the difference between a torrent
+            // bug that can be read off a log and one that can only be guessed at.
+            try {
+                torrentEngine.stream(hash, season, episode, fileIndex, range.start, range.endInclusive, this)
+            } catch (cancellation: CancellationException) {
+                throw cancellation // the viewer closing the player is not a fault
+            } catch (failure: Throwable) {
+                // Every seek ends one response and opens another with a fresh Range, so the
+                // player dropping a connection mid-write is the ordinary case rather than a
+                // fault, and a line per seek would bury the failures worth reading. Ask the
+                // channel instead of matching exception types: a hangup surfaces as any of
+                // ClosedWriteChannelException, ClosedByteChannelException or a plain IOException
+                // carrying "Broken pipe", and a list of those would quietly rot.
+                if (isClosedForWrite) throw failure
+                System.err.println(
+                    "Cove torrent: stream failed for $hash after the response started — " +
+                        "${failure::class.simpleName}: ${failure.message}",
+                )
+                throw failure
+            }
         }
     }
 

--- a/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/torrent/AndroidJlibtorrentPlaybackEngine.kt
+++ b/app/backend/src/androidMain/kotlin/com/coveninja/cove/backend/torrent/AndroidJlibtorrentPlaybackEngine.kt
@@ -1,7 +1,9 @@
 package com.coveninja.cove.backend.torrent
 
 import com.frostwire.jlibtorrent.Priority
+import com.frostwire.jlibtorrent.Sha1Hash
 import com.frostwire.jlibtorrent.SessionManager
+import com.frostwire.jlibtorrent.TorrentFlags
 import com.frostwire.jlibtorrent.TorrentHandle
 import com.frostwire.jlibtorrent.TorrentInfo
 import com.coveninja.cove.backend.storage.TorrentCacheJournal
@@ -193,27 +195,70 @@ internal class AndroidJlibtorrentPlaybackEngine(
         manager = null
     }
 
+    /** Waits for metadata on the live handle, then caches it for the next play. */
+    private suspend fun awaitTorrentMetadata(
+        handle: TorrentHandle,
+        hash: String,
+        cachePath: Path,
+    ): TorrentInfo {
+        awaitMetadata(
+            hash = hash,
+            timeoutMillis = metadataTimeoutSeconds * 1_000L,
+            hasMetadata = { handle.status().hasMetadata() },
+            peerCount = { handle.status().numPeers() },
+            log = ::log,
+            diagnostics = {
+                val current = manager
+                val dht = runCatching {
+                    "dht=${current?.isDhtRunning} nodes=${current?.dhtNodes()}"
+                }.getOrDefault("dht=?")
+                val trackers = runCatching { handle.trackers().size }.getOrDefault(-1)
+                "$dht, $trackers trackers"
+            },
+        )
+        val fetched = handle.torrentFile()
+        // Cached after it parses, so metadata that does not decode is never written and the next
+        // attempt refetches rather than failing fast.
+        runCatching { if (fetched.isValid) Files.write(cachePath, fetched.bencode()) }
+        return fetched
+    }
+
     private suspend fun loadTorrent(hash: String): ManagedTorrent {
         val session = session()
         val torrentDirectory = downloadDirectory.resolve(hash).toAbsolutePath().normalize()
         val metadataDirectory = downloadDirectory.resolve("metadata").toAbsolutePath().normalize()
         Files.createDirectories(torrentDirectory)
         Files.createDirectories(metadataDirectory)
-        val metadata = session.fetchMagnet(
-            "magnet:?xt=urn:btih:$hash",
-            metadataTimeoutSeconds,
-            metadataDirectory.toFile(),
-        ) ?: throw IllegalStateException("timed out fetching torrent metadata")
-        val info = TorrentInfo(metadata)
-        session.download(info, torrentDirectory.toFile())
-        val handle = withTimeout(10_000) {
+        // Metadata a previous play already paid for. The second episode of a series, and every
+        // resume of one, skips straight to asking for pieces.
+        val cachedMetadata = metadataDirectory.resolve("$hash.torrent")
+        val cached = readCachedMetadata(cachedMetadata, hash)
+        // Added exactly once, and never taken back out.
+        //
+        // The obvious way to do this — fetchMagnet for the metadata, then download() for the
+        // content — costs the entire swarm. fetchMagnet adds the torrent, waits for metadata and
+        // then *removes* it, so the second add starts from nothing: another DHT lookup, another
+        // tracker announce, another round of peer handshakes, all of which had already completed
+        // moments earlier. That second cold start is the wait, and it is why the first play of
+        // anything timed out here while the desktop, which has added the magnet once and held
+        // onto it since, was watching video.
+        log("$hash: adding torrent — metadata ${if (cached != null) "from cache" else "from magnet"}")
+        if (cached != null) {
+            session.download(cached, torrentDirectory.toFile())
+        } else {
+            session.download(magnetUri(hash), torrentDirectory.toFile(), TorrentFlags.SEQUENTIAL_DOWNLOAD)
+        }
+        val handle = withTimeout(HANDLE_TIMEOUT_MILLIS) {
             var found: TorrentHandle? = null
             while (found == null) {
-                found = session.find(info)
-                if (found == null) delay(50)
+                found = session.find(Sha1Hash(hash))
+                if (found == null) delay(TORRENT_POLL_MILLIS)
             }
             found
         }
+        // The metadata now arrives on the handle that is already talking to peers, rather than
+        // on a throwaway one.
+        val info = cached ?: awaitTorrentMetadata(handle, hash, cachedMetadata)
         val storage = info.files()
         val files = (0 until storage.numFiles()).map { index ->
             TorrentFile(index, storage.filePath(index), storage.fileSize(index))
@@ -336,3 +381,7 @@ private fun contentType(name: String): String = when (name.substringAfterLast('.
     "ts", "m2ts" -> "video/mp2t"
     else -> "video/x-matroska"
 }
+
+// Matches the desktop engine: plain stderr, no logging framework, one "Cove" prefix so the
+// line is findable in logcat and in a terminal alike.
+private fun log(message: String) = System.err.println("Cove torrent: $message")

--- a/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/http/MediaBoundary.kt
+++ b/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/http/MediaBoundary.kt
@@ -146,7 +146,28 @@ class MediaBoundary(
             status = if (range.partial) HttpStatusCode.PartialContent else HttpStatusCode.OK,
             contentLength = range.endInclusive - range.start + 1,
         ) {
-            engine.stream(hash, season, episode, fileIndex, range.start, range.endInclusive, this)
+            // Same reasoning as the open above, for the half of the work that happens after the
+            // 206 is already on the wire. Ktor reports a producer failure to its own logger
+            // rather than to the caller, so without this the connection simply dies and the
+            // sentence the viewer sees is the only trace left.
+            try {
+                engine.stream(hash, season, episode, fileIndex, range.start, range.endInclusive, this)
+            } catch (cancellation: CancellationException) {
+                throw cancellation // the viewer closing the player is not a fault
+            } catch (failure: Throwable) {
+                // Every seek ends one response and opens another with a fresh Range, so the
+                // player dropping a connection mid-write is the ordinary case rather than a
+                // fault, and a line per seek would bury the failures worth reading. Ask the
+                // channel instead of matching exception types: a hangup surfaces as any of
+                // ClosedWriteChannelException, ClosedByteChannelException or a plain IOException
+                // carrying "Broken pipe", and a list of those would quietly rot.
+                if (isClosedForWrite) throw failure
+                System.err.println(
+                    "Cove torrent: stream failed for $hash after the response started — " +
+                        "${failure::class.simpleName}: ${failure.message}",
+                )
+                throw failure
+            }
         }
     }
 

--- a/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/torrent/JlibtorrentPlaybackEngine.kt
+++ b/app/backend/src/desktopMain/kotlin/com/coveninja/cove/backend/torrent/JlibtorrentPlaybackEngine.kt
@@ -308,62 +308,29 @@ class JlibtorrentPlaybackEngine(
         hash: String,
         cachePath: Path,
     ): TorrentInfo {
-        val started = System.currentTimeMillis()
-        var reportedAt = started
-        while (!handle.status().hasMetadata()) {
-            val elapsed = System.currentTimeMillis() - started
-            val peers = runCatching { handle.status().numPeers() }.getOrDefault(0)
-            if (elapsed >= metadataTimeoutSeconds * 1_000L) {
-                log("$hash: no metadata after ${elapsed / 1_000}s, $peers peers — giving up")
-                throw IllegalStateException(
-                    "timed out fetching torrent metadata after ${elapsed / 1_000}s with $peers peers",
-                )
-            }
-            if (elapsed >= DEAD_SWARM_MILLIS && peers == 0) {
-                log("$hash: no peers at all after ${elapsed / 1_000}s — treating the source as dead")
-                throw IllegalStateException(
-                    "no peers found for this torrent after ${elapsed / 1_000}s — the source looks dead",
-                )
-            }
-            if (System.currentTimeMillis() - reportedAt >= PROGRESS_REPORT_MILLIS) {
-                reportedAt = System.currentTimeMillis()
-                // The session's own state alongside the peer count: zero peers with a
-                // dead DHT and no trackers is a session that never got started
-                // properly, which looks identical from the outside to a torrent
-                // nobody is seeding.
+        awaitMetadata(
+            hash = hash,
+            timeoutMillis = metadataTimeoutSeconds * 1_000L,
+            hasMetadata = { handle.status().hasMetadata() },
+            peerCount = { handle.status().numPeers() },
+            log = ::log,
+            diagnostics = {
                 val session = manager
                 val dht = runCatching {
                     "dht=${session?.isDhtRunning} nodes=${session?.dhtNodes()}"
                 }.getOrDefault("dht=?")
                 val trackers = runCatching { handle.trackers().size }.getOrDefault(-1)
-                log("$hash: waiting for metadata, ${elapsed / 1_000}s elapsed, $peers peers, $dht, $trackers trackers")
-            }
-            delay(PIECE_POLL_MILLIS)
-        }
+                "$dht, $trackers trackers"
+            },
+            pollMillis = PIECE_POLL_MILLIS,
+        )
         val fetched = handle.torrentFile()
-        log("$hash: metadata in ${System.currentTimeMillis() - started}ms")
         // Cached after it parses, so metadata that does not decode is never written
         // and the next attempt refetches rather than failing fast.
         runCatching { if (fetched.isValid) Files.write(cachePath, fetched.bencode()) }
         return fetched
     }
 
-    /**
-     * Reads metadata cached by an earlier play, or null if there is none to read.
-     *
-     * A corrupt or truncated file reads as "no cache" rather than as an error: the
-     * fetch that follows is slow, not broken, and losing a torrent to a bad cache
-     * entry would be a far worse trade than paying for the metadata again.
-     */
-    private fun readCachedMetadata(path: Path, hash: String): TorrentInfo? = runCatching {
-        TorrentInfo(path.toFile()).takeIf { info ->
-            // The info hash is checked rather than trusted from the file name: a
-            // cache entry that decodes to a different torrent would otherwise send
-            // the player off downloading something else entirely, and the find()
-            // below would search for a handle that was never added.
-            info.isValid && info.infoHashV1()?.toHex().equals(hash, ignoreCase = true)
-        }
-    }.getOrNull()
 
     private suspend fun session(): SessionManager = startMutex.withLock {
         // Before the first touch of any jlibtorrent class, which is what loads its
@@ -598,43 +565,9 @@ private const val DEADLINE_STEP_MILLIS = 50
 
 private const val PIECE_POLL_MILLIS = 50L
 
-/** How long the session is given to register a torrent that was just added. */
-private const val HANDLE_TIMEOUT_MILLIS = 15_000L
-
-/** How long a torrent may find nobody at all before it is called dead. */
-private const val DEAD_SWARM_MILLIS = 20_000L
-
-/** How often a wait long enough to be noticed reports what it is waiting on. */
-private const val PROGRESS_REPORT_MILLIS = 5_000L
-
 // Matches LocalBackendHost: plain stderr, no logging framework, one "Cove" prefix
 // so a user's terminal shows where the line came from.
 private fun log(message: String) = System.err.println("Cove torrent: $message")
-
-/**
- * Trackers appended to every magnet.
- *
- * A bare `magnet:?xt=urn:btih:` leaves DHT and peer exchange as the only way to
- * find anybody, which on a cold start means waiting out a DHT lookup before the
- * first byte moves — and for a poorly-seeded torrent it can mean never finding
- * the peers a tracker would have handed over immediately. These are the open
- * trackers the public swarms already announce to, so this asks the same servers
- * the torrent's own announce list would have.
- */
-private val DEFAULT_TRACKERS = listOf(
-    "udp://tracker.opentrackr.org:1337/announce",
-    "udp://open.tracker.cl:1337/announce",
-    "udp://tracker.openbittorrent.com:6969/announce",
-    "udp://exodus.desync.com:6969/announce",
-    "udp://tracker.torrent.eu.org:451/announce",
-)
-
-private fun magnetUri(hash: String): String = buildString {
-    append("magnet:?xt=urn:btih:").append(hash)
-    for (tracker in DEFAULT_TRACKERS) {
-        append("&tr=").append(URLEncoder.encode(tracker, StandardCharsets.UTF_8))
-    }
-}
 
 private fun contentType(name: String): String = when (name.substringAfterLast('.', "").lowercase()) {
     "mp4", "m4v" -> "video/mp4"

--- a/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/torrent/TorrentMetadataTest.kt
+++ b/app/backend/src/desktopTest/kotlin/com/coveninja/cove/backend/torrent/TorrentMetadataTest.kt
@@ -1,0 +1,95 @@
+package com.coveninja.cove.backend.torrent
+
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.test.runTest
+
+class TorrentMetadataTest {
+    private val hash = "3ae0584c0f02527a2e649be1b9fc487718625eea"
+
+    @Test
+    fun `a magnet carries the trackers a bare info hash would not`() {
+        val magnet = magnetUri(hash)
+
+        assertTrue(magnet.startsWith("magnet:?xt=urn:btih:$hash"))
+        // Mutation check: dropping the tracker loop leaves only the xt parameter and fails
+        // here. This is the difference between a cold start that can reach a tracker and one
+        // that can only wait out a DHT lookup.
+        assertEquals(DEFAULT_TRACKERS.size, magnet.split("&tr=").size - 1)
+        // Percent-encoded, or the ':' and '/' in a tracker URL would terminate the parameter
+        // early and every announce would go to a truncated address.
+        assertContains(magnet, "udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce")
+    }
+
+    @Test
+    fun `waiting ends as soon as the metadata lands`() = runTest {
+        var polls = 0
+        val lines = mutableListOf<String>()
+
+        awaitMetadata(
+            hash = hash,
+            timeoutMillis = 45_000,
+            hasMetadata = { polls++ >= 3 },
+            peerCount = { 4 },
+            log = lines::add,
+            pollMillis = 1,
+            nowMillis = { 0 },
+        )
+
+        // Mutation check: returning true immediately makes this 1, and inverting the
+        // condition never terminates.
+        assertEquals(4, polls)
+        assertTrue(lines.single().contains("metadata in"))
+    }
+
+    @Test
+    fun `a swarm with no peers at all is called dead before the full timeout`() = runTest {
+        var clock = 0L
+        val lines = mutableListOf<String>()
+
+        val failure = assertFailsWith<IllegalStateException> {
+            awaitMetadata(
+                hash = hash,
+                timeoutMillis = 45_000,
+                hasMetadata = { false },
+                peerCount = { 0 },
+                log = lines::add,
+                pollMillis = 1,
+                nowMillis = { clock += 1_000; clock },
+            )
+        }
+
+        // Mutation check: removing the dead-swarm branch makes this report the 45s timeout
+        // instead, and raising DEAD_SWARM_MILLIS above the timeout does the same.
+        assertContains(failure.message.orEmpty(), "the source looks dead")
+        assertTrue(clock < 45_000, "gave up at ${clock}ms, which is not early")
+    }
+
+    @Test
+    fun `a slow swarm that has found peers keeps the whole window`() = runTest {
+        var clock = 0L
+        val lines = mutableListOf<String>()
+
+        val failure = assertFailsWith<IllegalStateException> {
+            awaitMetadata(
+                hash = hash,
+                timeoutMillis = 45_000,
+                hasMetadata = { false },
+                peerCount = { 2 },
+                log = lines::add,
+                pollMillis = 1,
+                nowMillis = { clock += 1_000; clock },
+            )
+        }
+
+        // Mutation check: dropping `peers == 0` from the dead-swarm branch fails here, because
+        // a torrent that is merely slow would be abandoned at 20s with peers in hand.
+        assertContains(failure.message.orEmpty(), "timed out fetching torrent metadata")
+        assertTrue(clock >= 45_000, "gave up at ${clock}ms, before the timeout")
+        // The wait says what it is waiting on rather than going quiet for 45 seconds.
+        assertTrue(lines.any { it.contains("waiting for metadata") })
+    }
+}

--- a/app/backend/src/jvmSharedMain/kotlin/com/coveninja/cove/backend/torrent/TorrentMetadata.kt
+++ b/app/backend/src/jvmSharedMain/kotlin/com/coveninja/cove/backend/torrent/TorrentMetadata.kt
@@ -1,0 +1,119 @@
+package com.coveninja.cove.backend.torrent
+
+import com.frostwire.jlibtorrent.TorrentInfo
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import java.nio.file.Path
+import kotlinx.coroutines.delay
+
+/**
+ * Getting a torrent's metadata, which is the whole of a cold start.
+ *
+ * Shared rather than written twice because it already was: the desktop engine learned each of
+ * these lessons and the Android one did not, so a phone kept paying a cold start the desktop
+ * had stopped paying — the viewer saw "The selected stream could not be opened" on the first
+ * play of anything and a working stream on the second.
+ */
+
+/**
+ * Trackers appended to every magnet.
+ *
+ * A bare `magnet:?xt=urn:btih:` leaves DHT and peer exchange as the only way to find anybody,
+ * which on a cold start means waiting out a DHT lookup before the first byte moves — and for a
+ * poorly-seeded torrent it can mean never finding the peers a tracker would have handed over
+ * immediately. These are the open trackers the public swarms already announce to, so this asks
+ * the same servers the torrent's own announce list would have.
+ */
+internal val DEFAULT_TRACKERS = listOf(
+    "udp://tracker.opentrackr.org:1337/announce",
+    "udp://open.tracker.cl:1337/announce",
+    "udp://tracker.openbittorrent.com:6969/announce",
+    "udp://exodus.desync.com:6969/announce",
+    "udp://tracker.torrent.eu.org:451/announce",
+)
+
+internal fun magnetUri(hash: String): String = buildString {
+    append("magnet:?xt=urn:btih:").append(hash)
+    for (tracker in DEFAULT_TRACKERS) {
+        append("&tr=").append(URLEncoder.encode(tracker, StandardCharsets.UTF_8))
+    }
+}
+
+/** How long the session is given to register a torrent that was just added. */
+internal const val HANDLE_TIMEOUT_MILLIS = 15_000L
+
+/** How long a torrent may find nobody at all before it is called dead. */
+internal const val DEAD_SWARM_MILLIS = 20_000L
+
+/** How often a wait long enough to be noticed reports what it is waiting on. */
+internal const val PROGRESS_REPORT_MILLIS = 5_000L
+
+/** Spacing between polls of a torrent handle that has not answered yet. */
+internal const val TORRENT_POLL_MILLIS = 50L
+
+/**
+ * Reads metadata cached by an earlier play, or null if there is none to read.
+ *
+ * A corrupt or truncated file reads as "no cache" rather than as an error: the fetch that
+ * follows is slow, not broken, and losing a torrent to a bad cache entry would be a far worse
+ * trade than paying for the metadata again.
+ */
+internal fun readCachedMetadata(path: Path, hash: String): TorrentInfo? = runCatching {
+    TorrentInfo(path.toFile()).takeIf { info ->
+        // The info hash is checked rather than trusted from the file name: a cache entry that
+        // decodes to a different torrent would otherwise send the player off downloading
+        // something else entirely, and the find() that follows would search for a handle that
+        // was never added.
+        info.isValid && info.infoHashV1()?.toHex().equals(hash, ignoreCase = true)
+    }
+}.getOrNull()
+
+/**
+ * Waits for a torrent's metadata, saying out loud how it is going.
+ *
+ * Gives up early on a swarm that has produced nobody at all: a source with zero peers after
+ * [DEAD_SWARM_MILLIS] is a dead link, not a slow one, and sitting on it for the full timeout
+ * only delays the viewer finding that out. A swarm that has found peers keeps the whole
+ * window — that one is working, just slowly.
+ *
+ * The handle is reached through lambdas rather than passed in, so the waiting itself can be
+ * tested without a live session.
+ */
+internal suspend fun awaitMetadata(
+    hash: String,
+    timeoutMillis: Long,
+    hasMetadata: () -> Boolean,
+    peerCount: () -> Int,
+    log: (String) -> Unit,
+    diagnostics: () -> String = { "" },
+    pollMillis: Long = TORRENT_POLL_MILLIS,
+    nowMillis: () -> Long = System::currentTimeMillis,
+) {
+    val started = nowMillis()
+    var reportedAt = started
+    while (!hasMetadata()) {
+        val elapsed = nowMillis() - started
+        val peers = runCatching(peerCount).getOrDefault(0)
+        if (elapsed >= timeoutMillis) {
+            log("$hash: no metadata after ${elapsed / 1_000}s, $peers peers — giving up")
+            throw IllegalStateException(
+                "timed out fetching torrent metadata after ${elapsed / 1_000}s with $peers peers",
+            )
+        }
+        if (elapsed >= DEAD_SWARM_MILLIS && peers == 0) {
+            log("$hash: no peers at all after ${elapsed / 1_000}s — treating the source as dead")
+            throw IllegalStateException(
+                "no peers found for this torrent after ${elapsed / 1_000}s — the source looks dead",
+            )
+        }
+        if (nowMillis() - reportedAt >= PROGRESS_REPORT_MILLIS) {
+            reportedAt = nowMillis()
+            // The session's own state alongside the peer count: zero peers with a dead DHT and
+            // no trackers is a session that never got started properly, which looks identical
+            // from the outside to a torrent nobody is seeding.
+            log("$hash: waiting for metadata, ${elapsed / 1_000}s elapsed, $peers peers, ${diagnostics()}")
+        }
+        delay(pollMillis)
+    }
+    log("$hash: metadata in ${nowMillis() - started}ms")
+}


### PR DESCRIPTION
The first play of any torrent failed on Android — "The selected stream could not be
opened" — while an immediate retry worked. Not a regression from libmpv 1.0.0; it
predates it.

### Cause

Metadata was acquired with `fetchMagnet` and then `download()`:

```kotlin
val metadata = session.fetchMagnet("magnet:?xt=urn:btih:$hash", …)  // adds, fetches, REMOVES
session.download(TorrentInfo(metadata), …)                          // adds again, from scratch
```

`fetchMagnet` removes the torrent once it has the metadata, so the download that
followed began a **second** cold approach: another DHT lookup, another tracker
announce, another round of peer handshakes — all of which had completed moments
earlier. The magnet was bare besides, leaving DHT as the only way to find anyone.

The desktop engine learned both lessons a while ago and documents them; Android never
received the fix. That drift is why the bug survived, so the shared parts now live in
`jvmSharedMain` rather than being copied a second time — alongside the existing
`DownloadWindow.kt` / `TorrentFileAvailability.kt`.

### Changes

- **`jvmSharedMain/torrent/TorrentMetadata.kt`** (new) — tracker list, magnet builder,
  metadata-cache reader, and the metadata wait. The handle is reached through lambdas so
  the waiting is testable without a live session.
- **Android** adds the magnet once with trackers and `SEQUENTIAL_DOWNLOAD`, then waits on
  the handle already talking to peers; caches metadata per info hash; gains dead-swarm
  detection.
- **Desktop** duplicates removed in favour of the shared code — a move, not a rewrite.
- **Both media hosts** now report a failure raised after the response has started. Ktor
  hands those to an SLF4J logger that binds no provider on Android, so the only account
  of what went wrong was being discarded — which is why this needed a live reproduction
  to find. A client hangup is excluded by asking the channel (`isClosedForWrite`) rather
  than matching exception types, since every seek ends one response and opens another,
  and Ktor raises several shapes for it.

### Measured on an emulator

| Case | Before | After |
|---|---|---|
| Cold start, live swarm | 45 s timeout, failed | **2.0 s**, plays |
| Second episode of a series | full fetch again | **0.2 s**, from cache |
| Genuinely unseeded torrent | 45 s, opaque failure | **20 s**, "the source looks dead" |

Three independent cold starts confirmed working (2.0 s, 2.5 s), the cache path confirmed,
and the dead-swarm path confirmed on a real unseeded torrent that showed 0 peers against a
healthy DHT with all 5 trackers attached.

### Tests

205 backend tests pass, including 4 new ones for the shared logic. Each new assertion was
mutation-checked: dropping the tracker loop, removing the dead-swarm branch, and ignoring
the peer count each fail the suite, and restoring turns it green.